### PR TITLE
Correct LBKT direction

### DIFF
--- a/keymap_drawer/config.py
+++ b/keymap_drawer/config.py
@@ -261,7 +261,7 @@ class ParseConfig(BaseSettings):
         "GREATER_THAN": ">",
         "GT": ">",
         "LEFT_BRACKET": "[",
-        "LBKT": "]",
+        "LBKT": "[",
         "LEFT_BRACE": "{",
         "LBRC": "{",
         "RIGHT_BRACKET": "]",


### PR DESCRIPTION
I noticed that the `LBKT` mapping was facing the wrong direction.