### PR TITLE
Replace underscores with spaces in unmapped QMK keys

### DIFF
--- a/keymap_drawer/parse.py
+++ b/keymap_drawer/parse.py
@@ -62,7 +62,7 @@ class QmkJsonParser(KeymapParser):
             return LayoutKey(tap=key_str)
 
         def mapped(key: str) -> str:
-            return self.cfg.qmk_keycode_map.get(key, key)
+            return self.cfg.qmk_keycode_map.get(key, key.replace("_", " "))
 
         key_str = self._prefix_re.sub("", key_str)
 


### PR DESCRIPTION
Similar to what the [ZMK parser already does](https://github.com/caksoylar/keymap-drawer/blob/main/keymap_drawer/parse.py#L123), replace underscores in unmapped QMK keys to allow their labels to be displayed on two lines.

```sh
❯ jq ".layers[7]" /tmp/keymap.json | tr "\n" " "
[   "RGB_VAI",   "RGB_SAI",   "RGB_HUI",   "RGB_MOD",   "RGB_TOG",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "QK_BOOT",   "KC_MPRV",   "KC_VOLD",   "KC_VOLU",   "KC_MNXT",   "EP_TOG",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "BT_CLR",   "BT_SEL2",   "BT_SEL1",   "BT_SEL0",   "OUT_TOG",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_NO",   "KC_MPLY",   "KC_MUTE",   "KC_NO",   "KC_HELD",   "KC_HELD" ]

❯ keymap parse -q /tmp/keymap.json | yq ".layers" | ag "L7:"
L7: [RGB VAI, RGB SAI, RGB HUI, RGB MOD, RGB TOG, '', '', '', '', QK BOOT, MPRV, VOLD, VOLU, MNXT, EP TOG, '', '', '', '', '', BT CLR, BT SEL2, BT SEL1, BT SEL0, OUT TOG, '', '', '', '', '', '', MPLY, MUTE, '', HELD, HELD]
```