### PR TITLE
Add custom glyph support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	"image": "mcr.microsoft.com/devcontainers/python:0-3.11",
+	"features": {
+		"ghcr.io/devcontainers-contrib/features/poetry": {}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Available as a [command-line tool](#command-line-tool-installation) or a [web ap
 - Bootstrap the YAML representation by automatically parsing QMK or ZMK keymap files
 - Arbitrary physical keyboard layouts (with rotated keys!) supported, along with parametrized ortho layouts
 - Both parsing and drawing are customizable with a config file, see ["Customization" section](#customization)
+- Custom glyph support, render custom svg icons and not just unicode
 
 See examples in [the live web demo](https://caksoylar.github.io/keymap-drawer) for example inputs and outputs.
 
@@ -136,6 +137,30 @@ KEYMAP_raw_binding_map='{"&bootloader": "BOOT"}' keymap parse -z zmk-config/conf
 ```
 
 Drawing parameters that are specified in the `draw_config` field can also be overridden in [the keymap YAML](KEYMAP_SPEC.md#draw_config).
+
+
+## Custom Glyphs
+Custom glyphs can be defined in the `drawing_config` block of the keymap config. After a glyph is defined it can be subsititued in place of text by surrounding the name with `$$` (i.e `$$vol_up$$`). The provided svg must only specify a viewBox, no positional or dimentional properties should be included as they are calculated for you. The height of the svg is bound by the config properties `glyph_{tap,hold,shifted}_size` and width will maintain aspect ratio. (see example). To allow for custom stuing glyphs are assigned css classes `glyph` and  `<glyph name>`.
+Example:
+```yaml
+draw_config:
+  # Specify the size to bound the vertical dimension of your glyph
+  glyph_tap_size: 12
+  glyph_hold_size: 10
+  glyph_shifted_size: 8
+  glyphs:
+    vol_up: |-
+      <svg viewBox="2 3 34 33">
+        <path style="stroke: black; fill: black;" d="M23.41,25.25a1,1,0,0,1-.54-1.85,6.21,6.21,0,0,0-.19-10.65,1,1,0,1,1,1-1.73,8.21,8.21,0,0,1,.24,14.06A1,1,0,0,1,23.41,25.25Z"/>
+        <path style="stroke: black; fill: black;" d="M25.62,31.18a1,1,0,0,1-.45-1.89A12.44,12.44,0,0,0,25,6.89a1,1,0,1,1,.87-1.8,14.44,14.44,0,0,1,.24,26A1,1,0,0,1,25.62,31.18Z"/>
+        <path style="stroke: black; fill: black;" d="M18.33,4,9.07,12h-6a1,1,0,0,0-1,1v9.92a1,1,0,0,0,1,1H8.88l9.46,8.24A1,1,0,0,0,20,31.43V4.72A1,1,0,0,0,18.33,4Z"/>
+      </svg>
+...
+layers:
+  Media:
+...
+    - ["","$$vol_up$$","","",""]
+```
 
 ## Development
 

--- a/keymap_drawer/__main__.py
+++ b/keymap_drawer/__main__.py
@@ -42,7 +42,9 @@ def draw(args, config: DrawConfig) -> None:
     drawer = KeymapDrawer(
         config=config, out=sys.stdout, layers=yaml_data["layers"], layout=layout, combos=yaml_data.get("combos", [])
     )
-    drawer.print_board(draw_layers=args.select_layers, keys_only=args.keys_only, combos_only=args.combos_only)
+    drawer.print_board(
+        draw_layers=args.select_layers, keys_only=args.keys_only, combos_only=args.combos_only, glyphs=config.glyphs
+    )
 
 
 def parse(args, config: ParseConfig) -> None:

--- a/keymap_drawer/config.py
+++ b/keymap_drawer/config.py
@@ -53,6 +53,18 @@ class DrawConfig(BaseSettings):
 
     svg_style: str = dedent(
         """\
+        /* Start Tabler Icons Cleanup */
+        /* cannot use height/width with glyphs */
+        .icon-tabler > path {
+            fill: inherit;
+            stroke: inherit;
+        }
+        /* hide tabler's default box */
+        .icon-tabler > path[stroke="none"][fill="none"] {
+            visibility: collapse;
+        }
+        /* End Tabler Icons Cleanup */
+
         /* inherit to force styles through use tags*/
         svg path {
             fill: inherit;

--- a/keymap_drawer/config.py
+++ b/keymap_drawer/config.py
@@ -53,8 +53,12 @@ class DrawConfig(BaseSettings):
 
     svg_style: str = dedent(
         """\
+        /* inherit to force styles through use tags*/
+        svg path {
+            fill: inherit;
+        }
         /* font and background color specifications */
-        svg {
+        svg.keymap {
             font-family: SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace;
             font-size: 14px;
             font-kerning: normal;
@@ -63,7 +67,7 @@ class DrawConfig(BaseSettings):
         }
 
         /* default key styling */
-        rect {
+        rect.key {
             fill: #f6f8fa;
             stroke: #c9cccf;
             stroke-width: 1;
@@ -126,6 +130,12 @@ class DrawConfig(BaseSettings):
         }
         """
     )
+
+    glyph_tap_size: int = 12
+    glyph_hold_size: int = 10
+    glyph_shifted_size: int = 8
+
+    glyphs: dict[str, str] = {}
 
 
 class ParseConfig(BaseSettings):

--- a/keymap_drawer/draw.py
+++ b/keymap_drawer/draw.py
@@ -309,8 +309,9 @@ class KeymapDrawer:
 
         self.out.write("<defs>/*start glyphs*/\n")
         for name, block in glyphs.items():
+            scrubbed=re.sub(r' (?:width|height)=\"([^"]*)\"', "", block)
             self.out.write(f'<svg id="{name}">\n')
-            self.out.write(block)
+            self.out.write(scrubbed)
             self.out.write("\n</svg>\n")
         self.out.write("</defs>/*end glyphs*/\n")
 

--- a/keymap_drawer/draw.py
+++ b/keymap_drawer/draw.py
@@ -23,10 +23,6 @@ class KeymapDrawer:
         assert self.keymap.config is not None, "A DrawConfig must be provided for drawing"
         self.layout = self.keymap.layout
         self.out = out
-        self.glyph_name = re.compile(r"\$\$(?P<glyph>.*)\$\$")
-        self.view_box_dimensions = re.compile(
-            r'<svg.*viewbox="(?P<x>[0-9]+)\s+(?P<y>[0-9]+)\s+(?P<w>[0-9]+)\s+(?P<h>[0-9]+)".*>', flags=re.IGNORECASE
-        )
 
     @staticmethod
     def _split_text(text: str) -> list[str]:
@@ -63,7 +59,7 @@ class KeymapDrawer:
         self.out.write("</text>\n")
 
     def _is_glyph(self, words: Sequence[str]) -> str | None:
-        if len(words) == 1 and (match := self.glyph_name.search(words[0])):
+        if len(words) == 1 and (match := re.search(re.compile(r"\$\$(?P<glyph>.*)\$\$"), words[0])):
             return match.group("glyph")
         return None
 
@@ -74,7 +70,8 @@ class KeymapDrawer:
         if not (glyph := self.cfg.glyphs.get(name)):
             return False
 
-        if not (view_box := self.view_box_dimensions.match(glyph)):
+        pattern = r'<svg.*viewbox="(?P<x>[0-9]+)\s+(?P<y>[0-9]+)\s+(?P<w>[0-9]+)\s+(?P<h>[0-9]+)".*>'
+        if not (view_box := re.match(pattern, glyph, flags=re.IGNORECASE)):
             return False
 
         shift = {"middle": 0.5, "top": 0, "bottom": 1}[align]


### PR DESCRIPTION
I wanted to add some custom non-unicode legends to my keys, so I threw this together. It allows users to define custom svg blocks as legends. 

I choose to use nested SVG tags in an attempt to make it easier for people to use. I hope this will let them just copy/paste svg blocks and be able to test them outside keymap-drawer.

Furthermore, I am not super experienced with how SVGs work so if there is a better way to do this let me know, I'd happily update it. Some work could be done to clean up having two strategies of rendering legends. If we are interested in that I can go back through and try to clean it up and maybe add a stdlib of baked in glyphs?

