### PR TITLE
feat: Add a base keymap for parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ Please refer to [the keymap schema specification](KEYMAP_SPEC.md) while making c
 
 It might be beneficial to start by `draw`'ing the current representation and iterate over these changes, especially for tweaking combo positioning.
 
+> **Note**
+>
+> If you need to re-parse a firmware file after it was changed, you can provide the previous parse output that you tweaked to the
+> parse command via `keymap parse -b old_keymap.yaml ... >new_keymap.yaml` and the tool will try to preserve your manual tweaks.
+
 ### Producing the SVG
 
 Final step is to produce the SVG representation using the **`keymap draw`** command.


### PR DESCRIPTION
Fixes #7.

Allows passing a base keymap to parsing via `keymap parse --base-keymap base.yaml ...` where certain properties will be inherited from in the parse output. As explained in the linked issue, this would help for repeated parses where users already manually added properties to the keymap YAML, such as held/ghost keys or combo alignment specifiers.

Currently the following logic applies for inheritance:

- For layers in the parse output if a layer with the same name is in the base keymap, then for each position on the layer inherit any property that is present in the base layer key but not explicitly set in parse output (typically `type` fields, could be `hold` or `shifted` fields)
- For combos in the parse output, find combos in the base keymap that has the same `key_positions`, then choose the one that has the most intersection w.r.t. the `layers` property as the "best match". Inherit properties that are set in the matching combo but not explicitly specified in the parsed combo (typically `align`, `offset` fields).