### PR TITLE
feat: Add `parse_config.zmk_combos` to augment parse output

### DIFF
--- a/keymap_drawer/config.py
+++ b/keymap_drawer/config.py
@@ -291,6 +291,10 @@ class ParseConfig(BaseSettings):
         "TILDE2": "~",
     }
 
+    # additional combo fields for a given combo node name in the keymap,
+    # e.g. {"combo_esc": {"align": "top", "offset": 0.5}}
+    zmk_combos: dict[str, dict] = {}
+
 
 class Config(BaseSettings):
     """All configuration settings used for this module."""

--- a/keymap_drawer/keymap.py
+++ b/keymap_drawer/keymap.py
@@ -63,6 +63,16 @@ class ComboSpec(BaseModel):
     class Config:  # pylint: disable=missing-class-docstring
         allow_population_by_field_name = True
 
+    @classmethod
+    def normalize_fields(cls, spec_dict: dict) -> dict:
+        """Normalize spec_dict so that each field uses its alias and key is parsed to LayoutKey."""
+        for name, field in cls.__fields__.items():
+            if name in spec_dict:
+                spec_dict[field.alias] = spec_dict.pop(name)
+        if key_spec := spec_dict.get("k"):
+            spec_dict["k"] = LayoutKey.from_key_spec(key_spec)
+        return spec_dict
+
     @validator("key", pre=True)
     def get_key(cls, val) -> LayoutKey:
         """Parse each key from its key spec."""


### PR DESCRIPTION
This is useful if you want to add align/offset properties to combos in advance, which you can specify using the DTS node name in the ZMK keymap. Addresses https://github.com/caksoylar/keymap-drawer/issues/7#issuecomment-1453771520.

cc: @infused-kim, if you could give it a shot!