### PR TITLE
feat: Discover matching layout data in config/

### DIFF
--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -75,8 +75,8 @@ jobs:
             echo "INFO:   got extra draw args: $draw_args"
 
             if [ -f "config/${keyboard}.json" ]; then
-              echo "INFO:   found config/${keyboard}.json";
-              draw_args+=" -j config/${keyboard}.json"
+                echo "INFO:   found config/${keyboard}.json";
+                draw_args+=" -j config/${keyboard}.json"
             fi
 
             keymap "${config_arg[@]}" parse -z "$keymap_file" $parse_args >"$keyboard.yaml" \

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -74,6 +74,11 @@ jobs:
             draw_args=$(get_args "${{ inputs.draw_args }}" "$keyboard")
             echo "INFO:   got extra draw args: $draw_args"
 
+            if [ -f "config/${keyboard}.json" ]; then
+              echo "INFO:   found config/${keyboard}.json";
+              draw_args+=" -j config/${keyboard}.json"
+            fi
+
             keymap "${config_arg[@]}" parse -z "$keymap_file" $parse_args >"$keyboard.yaml" \
             && keymap "${config_arg[@]}" draw "$keyboard.yaml" $draw_args >"${{ inputs.output_folder }}/$keyboard.svg" \
             || echo "ERROR: parsing or drawing failed for $keyboard!"


### PR DESCRIPTION
I guess this is more of a proof of concept pending how configurable you want this to be. The idea is to support automatically detecting locally provided layout data. It follows the convention I'm using in keymap-editor, looking for `<keyboard>.json` instead of `info.json` (I switched to the former a while back to support multiple keymaps in one repo without requiring branching).

Couple of notes:

- It basically ignores `keymap_patterns` and looks exclusively for JSON files under `config/`
- I haven't used keymap-drawer enough to be familiar with how alternate layouts are handled. In keymap-editor I have auto-generated layouts from parsed matrix transforms, and at runtime I look for a chosen node in the keymap. I know that some of the layouts here (corne, for example) follow QMK layout naming conventions but the yaml mapping is only keyed by keyboard name.