### PR TITLE
Allow amending commit vs. creating one, add YAML

### DIFF
--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -15,8 +15,8 @@ on:
         required: false
         type: string
       output_folder:
-        description: "Output folder for SVGs"
-        default: "svg"
+        description: "Output folder for SVG and YAML files"
+        default: "keymap-drawer"
         required: false
         type: string
       parse_args:
@@ -30,10 +30,15 @@ on:
         required: false
         type: string
       commit_message:
-        description: "Commit message for updated images"
-        default: "[Skip CI] keymap-drawer render"
+        description: "Commit message for updated images. Ignored if `amend_commit` is `true`."
+        default: "keymap-drawer render"
         required: false
         type: string
+      amend_commit:
+        description: "Whether to amend the last commit instead of creating a new one. Make sure you understand the implications of rewriting the branch history if you use this option!"
+        default: false
+        required: false
+        type: boolean
       install_branch:
         description: "Install keymap-drawer from a git branch, use empty for pypi release (default)"
         default: ""
@@ -47,53 +52,78 @@ jobs:
       contents: write
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3      
-    - name: Install keymap-drawer (pypi)
-      if: inputs.install_branch == ''
-      run: python3 -m pip install keymap-drawer
-    - name: Install keymap-drawer (git)
-      if: inputs.install_branch != ''
-      run: python3 -m pip install "git+https://github.com/caksoylar/keymap-drawer.git@${{ inputs.install_branch }}"
-    - name: Draw keymaps
-      run: |
-        get_args() {
-            local keyboard=$2
-            eval set -- "$1"
-            for arg; do
-                local key=${arg%%:*}
-                local val=${arg#*:}
-                if [ "$key" = "$keyboard" ]; then
-                    echo "$val"
-                    break
-                fi
-            done
-        }
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # So the reference to the parent commit is available when amending
+          # See:
+          # - https://github.com/stefanzweifel/git-auto-commit-action#using---amend-and---no-edit-as-commit-options
+          # - https://github.com/stefanzweifel/git-auto-commit-action/issues/159#issuecomment-845347950
+          # - https://github.com/actions/checkout
+          fetch-depth: ${{ (inputs.amend_commit == true && 2) || 1 }}
 
-        mkdir -p "${{ inputs.output_folder }}"
+      - name: Install keymap-drawer (pypi)
+        if: inputs.install_branch == ''
+        run: python3 -m pip install keymap-drawer
 
-        config_path="${{ inputs.config_path }}"
-        [ -e "$config_path" ] && config_arg=(-c "$config_path") || config_arg=()
-        for keymap_file in ${{ inputs.keymap_patterns }}; do
-            keyboard=$(basename -s .keymap "$keymap_file")
-            echo "INFO: drawing for $keyboard"
+      - name: Install keymap-drawer (git)
+        if: inputs.install_branch != ''
+        run: python3 -m pip install "git+https://github.com/caksoylar/keymap-drawer.git@${{ inputs.install_branch }}"
 
-            parse_args=$(get_args "${{ inputs.parse_args }}" "$keyboard")
-            echo "INFO:   got extra parse args: $parse_args"
-            draw_args=$(get_args "${{ inputs.draw_args }}" "$keyboard")
-            echo "INFO:   got extra draw args: $draw_args"
+      - name: Draw keymaps
+        run: |
+          get_args() {
+              local keyboard=$2
+              eval set -- "$1"
+              for arg; do
+                  local key=${arg%%:*}
+                  local val=${arg#*:}
+                  if [ "$key" = "$keyboard" ]; then
+                      echo "$val"
+                      break
+                  fi
+              done
+          }
 
-            if [ -f "config/${keyboard}.json" ]; then
-                echo "INFO:   found config/${keyboard}.json";
-                draw_args+=" -j config/${keyboard}.json"
-            fi
+          mkdir -p "${{ inputs.output_folder }}"
 
-            keymap "${config_arg[@]}" parse -z "$keymap_file" $parse_args >"$keyboard.yaml" \
-            && keymap "${config_arg[@]}" draw "$keyboard.yaml" $draw_args >"${{ inputs.output_folder }}/$keyboard.svg" \
-            || echo "ERROR: parsing or drawing failed for $keyboard!"
-        done
-    - name: Commit updated images
-      uses: stefanzweifel/git-auto-commit-action@v4
-      with:
-        commit_message: "${{ inputs.commit_message }}"
-        file_pattern: "${{ inputs.output_folder }}/*.svg"
+          config_path="${{ inputs.config_path }}"
+          [ -e "$config_path" ] && config_arg=(-c "$config_path") || config_arg=()
+          for keymap_file in ${{ inputs.keymap_patterns }}; do
+              keyboard=$(basename -s .keymap "$keymap_file")
+              echo "INFO: drawing for $keyboard"
+
+              parse_args=$(get_args "${{ inputs.parse_args }}" "$keyboard")
+              echo "INFO:   got extra parse args: $parse_args"
+              draw_args=$(get_args "${{ inputs.draw_args }}" "$keyboard")
+              echo "INFO:   got extra draw args: $draw_args"
+
+              if [ -f "config/${keyboard}.json" ]; then
+                  echo "INFO:   found config/${keyboard}.json";
+                  draw_args+=" -j config/${keyboard}.json"
+              fi
+
+              keymap "${config_arg[@]}" parse -z "$keymap_file" $parse_args >"${{ inputs.output_folder }}/$keyboard.yaml" \
+              && keymap "${config_arg[@]}" draw "${{ inputs.output_folder }}/$keyboard.yaml" $draw_args >"${{ inputs.output_folder }}/$keyboard.svg" \
+              || echo "ERROR: parsing or drawing failed for $keyboard!"
+          done
+
+      - name: Get last commit message
+        id: last_commit_message
+        if: inputs.amend_commit == true
+        run: |
+          echo "msg=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT
+
+      - name: Commit updated images
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          file_pattern: "${{ inputs.output_folder }}/*.svg ${{ inputs.output_folder }}/*.yaml"
+          # So the previous commit is amended instead of creating a new one when desired
+          # See:
+          # - https://github.com/stefanzweifel/git-auto-commit-action#using---amend-and---no-edit-as-commit-options
+          # - https://github.com/stefanzweifel/git-auto-commit-action/issues/159#issuecomment-845347950
+          # - https://github.com/actions/checkout
+          commit_message: "${{ (inputs.amend_commit == true && steps.last_commit_message.outputs.msg) || inputs.commit_message }}"
+          commit_options: "${{ (inputs.amend_commit == true && '--amend --no-edit') || '' }}"
+          push_options: "${{ (inputs.amend_commit == true && '--force-with-lease') || '' }}"
+          skip_fetch: ${{ inputs.amend_commit == true }}

--- a/README.md
+++ b/README.md
@@ -218,7 +218,6 @@ jobs:
 
 Alternatively, you can choose to amend the triggering commit instead of generating a new one by using the `amend_commit: true` option. In this case the triggering commit's message will be used by default, and the `commit_message` input will be ignored. E.g.:
 
-
 ```yaml
 jobs:
   draw:

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Fetched SVGs will be [cached by default](keymap_drawer/config.py#L166) to speed 
 
 ## Setting up an automated drawing workflow
 
-If you use a [ZMK config repo](https://zmk.dev/docs/user-setup), you can set up an automated workflow to parse your keymaps, then draw and commit SVG outputs to your repo.
+If you use a [ZMK config repo](https://zmk.dev/docs/user-setup), you can set up an automated workflow that parses and draws your keymaps, then commits the YAML parse outputs and produced SVGs to your repo.
 To do that you can add a new workflow to your repo at `.github/workflows/draw-keymaps.yml` that refers to the reusable `keymap-drawer` [workflow](.github/workflows/draw-zmk.yml):
 
 ```yaml
@@ -197,10 +197,39 @@ jobs:
     with:
       keymap_patterns: "config/*.keymap"        # path to the keymaps to parse
       config_path: "keymap_drawer.config.yaml"  # config file, ignored if not exists
-      output_folder: "svg"                      # path to save produced SVGs
+      output_folder: "keymap-drawer"            # path to save produced SVG and keymap YAML files
       parse_args: ""  # map of extra args to pass to `keymap parse`, e.g. "corne:'-l Def Lwr Rse' cradio:''"
       draw_args: ""   # map of extra args to pass to `keymap draw`, e.g. "corne:'-k corne_rotated' cradio:'-k paroxysm'"
 ```
+
+### Modifying the workflow-generated commit
+
+The workflow will add the generated SVG and keymap representation YAML files to the `output-folder`, and generate a new `"keymap-drawer render"` commit by default. You can modify this commit message with the `commit_message` input param, e.g.:
+
+```yaml
+jobs:
+  draw:
+    uses: caksoylar/keymap-drawer/.github/workflows/draw-zmk.yml@main
+    with:
+      # Use the triggering commit's message, prepending the "[Draw]" tag
+      commit_message: "[Draw] ${{ github.event.head_commit.message }}"
+      # …other inputs
+```
+
+Alternatively, you can choose to amend the triggering commit instead of generating a new one by using the `amend_commit: true` option. In this case the triggering commit's message will be used by default, and the `commit_message` input will be ignored. E.g.:
+
+
+```yaml
+jobs:
+  draw:
+    uses: caksoylar/keymap-drawer/.github/workflows/draw-zmk.yml@main
+    with:
+      amend_commit: true
+      # …other inputs
+```
+
+> **Warning**
+> You should understand the implications of rewriting history if you amend a commit that has already been published. See [remarks](https://git-scm.com/docs/git-rebase#_recovering_from_upstream_rebase) in `git-rebase` documentation.
 
 ## Community
 


### PR DESCRIPTION
@caksoylar how terrible of an idea is this?

This PR:

- Adds a new `ammend_commit` (`boolean`) github action input which, when set to `true` it, well, ammends the commit which triggered the action, instead of creating a new one.
- Adds the YAML in the commit as well, so it can be loaded on the keymap-drawer UI at a later time if desired


### TODO:

- [x] Update docs (including a `Warning` like the one from `git-auto-commit-action`, e.g. below)


> **Warning**
You should understand the implications of rewriting history if you amend a commit that has already been published. [See rebasing](https://git-scm.com/docs/git-rebase#_recovering_from_upstream_rebase).

You can see it working here https://github.com/minusfive/zmk-config/commits/main

Action YAML:

```yaml
name: Draw ZMK keymaps
on:
  workflow_dispatch: # can be triggered manually
  push: # automatically run on changes to following paths
    paths:
      - "config/*.keymap"
      - "config/*.dtsi"
      - "keymap_drawer.config.yaml"

jobs:
  draw:
    uses: minusfive/keymap-drawer/.github/workflows/draw-zmk.yml@commit-options
    permissions:
      contents: write
    with:
      install_branch: "main" # branch to install keymap-drawer from
      keymap_patterns: "config/*.keymap" # path to the keymaps to parse
      config_path: "keymap_drawer.config.yaml" # config file, ignored if not exists
      output_folder: "img" # path to save produced SVGs
      # commit_message: "Draw: ${{ github.event.head_commit.message }}"
      ammend_commit: true # whether to ammend the commit or create a new one
```

A few things to note:

- I tested simply allowing the user to set any commit / push options they'd like, but deemed it too dangerous, as you really have to get all the pieces right to avoid messing up the history (e.g. checkout depth, skip_fetch, etc). So figured better/safer to make it a simple boolean option
- You don't need the `[Skip CI]` flag on the commit message as github automatically disables CI for action-generated commits, see:
  - https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs
  - https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs.