### PR TITLE
Implemented keys style

### DIFF
--- a/keymap_drawer/config.py
+++ b/keymap_drawer/config.py
@@ -57,7 +57,7 @@ class DrawConfig(BaseSettings, env_prefix="KEYMAP_", extra="ignore"):
         # position of internal key rectangle relative to the center of the key
         "rel_x": 0,
         "rel_y": -2.5,
-        # dimension of internal key rectangle relative to the center of the key
+        # delta dimension between extenal key rectangle and internal key rectangle
         "rel_w": -12,
         "rel_h": -12,
         # curvature of rounded internal key rectangle

--- a/keymap_drawer/config.py
+++ b/keymap_drawer/config.py
@@ -45,22 +45,25 @@ class DrawConfig(BaseSettings, env_prefix="KEYMAP_", extra="ignore"):
     # padding from edge of cap to top and bottom legends
     small_pad: float = 2.0
 
-    # relative position of key legend
+    # position of key legend relative to the center of the key
     legend_rel_x: float = 0
     legend_rel_y: float = 0
 
-    # change key style: default, base
-    keys_style: str = "default"
+    # draw key sides
+    draw_key_sides: bool = False
 
-    # relative position of external key rectangle
-    key_base_tile_rel_x: float = 0
-    key_base_tile_rel_y: float = -2.5
-    # relative dimension of internal key rectangles
-    key_base_tile_rel_w: float = -12
-    key_base_tile_rel_h: float = -12
-    # curvature of rounded internal key rectangles
-    key_base_tile_rx: float = 4.5
-    key_base_tile_ry: float = 4.5
+    # key sides configurations
+    key_sides: dict[str, float] = {
+        # position of internal key rectangle relative to the center of the key
+        "rel_x": 0,
+        "rel_y": -2.5,
+        # dimension of internal key rectangle relative to the center of the key
+        "rel_w": -12,
+        "rel_h": -12,
+        # curvature of rounded internal key rectangle
+        "rx": 4.5,
+        "ry": 4.5,
+    }
 
     svg_style: str = dedent(
         """\

--- a/keymap_drawer/config.py
+++ b/keymap_drawer/config.py
@@ -49,8 +49,8 @@ class DrawConfig(BaseSettings, env_prefix="KEYMAP_", extra="ignore"):
     legend_rel_x: float = 0
     legend_rel_y: float = 0
 
-    # change key style: None, base-tile
-    keys_style: str = None
+    # change key style: default, base
+    keys_style: str = "default"
 
     # relative position of external key rectangle
     key_base_tile_rel_x: float = 0

--- a/keymap_drawer/config.py
+++ b/keymap_drawer/config.py
@@ -45,6 +45,23 @@ class DrawConfig(BaseSettings, env_prefix="KEYMAP_", extra="ignore"):
     # padding from edge of cap to top and bottom legends
     small_pad: float = 2.0
 
+    # relative position of key legend
+    legend_rel_x: float = 0
+    legend_rel_y: float = 0
+
+    # change key style: None, base-tile
+    keys_style: str = None
+
+    # relative position of external key rectangle
+    key_base_tile_rel_x: float = 0
+    key_base_tile_rel_y: float = -2.5
+    # relative dimension of internal key rectangles
+    key_base_tile_rel_w: float = -12
+    key_base_tile_rel_h: float = -12
+    # curvature of rounded internal key rectangles
+    key_base_tile_rx: float = 4.5
+    key_base_tile_ry: float = 4.5
+
     svg_style: str = dedent(
         """\
         /* inherit to force styles through use tags*/
@@ -60,11 +77,21 @@ class DrawConfig(BaseSettings, env_prefix="KEYMAP_", extra="ignore"):
             fill: #24292e;
         }
 
+        /* default key background styling  */
+        rect.key-background, rect.held-background, rect.ghost-background {
+            fill: black
+        }
+
         /* default key styling */
-        rect.key {
+        rect.key, rect.key-side {
             fill: #f6f8fa;
             stroke: #c9cccf;
             stroke-width: 1;
+        }
+
+        /* default key side styling */
+        rect.key-side, rect.held-side, rect.ghost-side {
+            opacity: 0.9;
         }
 
         /* color accent for combo boxes */
@@ -73,12 +100,12 @@ class DrawConfig(BaseSettings, env_prefix="KEYMAP_", extra="ignore"):
         }
 
         /* color accent for held keys */
-        rect.held, rect.combo.held {
+        rect.held, rect.combo.held, rect.held-side {
             fill: #fdd;
         }
 
         /* color accent for ghost (optional) keys */
-        rect.ghost, rect.combo.ghost {
+        rect.ghost, rect.combo.ghost, rect.ghost-side {
             stroke-dasharray: 4, 4;
             stroke-width: 2;
         }

--- a/keymap_drawer/draw.py
+++ b/keymap_drawer/draw.py
@@ -6,7 +6,7 @@ representation of the keymap using these two.
 from math import copysign
 from html import escape
 from copy import deepcopy
-from typing import Sequence, TextIO, Literal
+from typing import Sequence, TextIO, Literal, Tuple, Dict
 
 from .keymap import KeymapData, ComboSpec, LayoutKey
 from .physical_layout import Point, PhysicalKey
@@ -38,42 +38,62 @@ class KeymapDrawer:
         # do not split on double spaces, but do split on single
         return [word.replace("\x00", " ") for word in text.replace("  ", "\x00").split()]
 
-    def _draw_rect(self, p: Point, w: float, h: float, rx: float, ry: float, classes: Sequence[str]) -> None:
+    def _draw_rect(self, p: Point, d: Tuple[str, float], r: Tuple[str, float], classes: Sequence[str]) -> None:
+        w, h = d
+        key_rx, key_ry = r
         self.out.write(
-            f'<rect rx="{rx}" ry="{ry}" x="{p.x - w / 2}" y="{p.y - h / 2}" '
+            f'<rect rx="{key_rx}" ry="{key_ry}" x="{p.x - w / 2}" y="{p.y - h / 2}" '
             f'width="{w}" height="{h}"{self._to_class_str(classes)}/>\n'
         )
 
-    def _draw_rect_styled(self, p: Point, w: float, h: float, tp: str, cl: str) -> None:
+    def _draw_rect_style_base(self, p: Point, d: Tuple[float, float], classes: Dict[str, str]) -> None:
+        # get key dimension
+        w, h = d
         # get curvature of rounded key rectangles from config
-        rx = self.cfg.key_rx
-        ry = self.cfg.key_ry
+        key_rx = self.cfg.key_rx
+        key_ry = self.cfg.key_ry
         # get inner pad from config
-        in_pad_h = self.cfg.inner_pad_h
         in_pad_w = self.cfg.inner_pad_w
+        in_pad_h = self.cfg.inner_pad_h
 
+        # draw external rectangle
+        # External rectangle is composed by 2 rectangles.
+        # The first is needed to have a black background (or what you want).
+        # The second is meant to be filled with the same color of the internal rectangle with some opacity.
+        self._draw_rect(
+            p,
+            (w - 2 * in_pad_w, h - 2 * in_pad_h),
+            (key_rx, key_ry),
+            classes=[classes["type"], f'{classes["class"]}-background'],
+        )
+        self._draw_rect(
+            p,
+            (w - 2 * in_pad_w, h - 2 * in_pad_h),
+            (key_rx, key_ry),
+            classes=[classes["type"], f'{classes["class"]}-side'],
+        )
+        # draw internal rectangle
+        self._draw_rect(
+            Point(p.x + self.cfg.key_base_tile_rel_x, p.y + self.cfg.key_base_tile_rel_y),
+            ((w + self.cfg.key_base_tile_rel_w) - 2 * in_pad_w, (h + self.cfg.key_base_tile_rel_h) - 2 * in_pad_h),
+            (self.cfg.key_base_tile_rx, self.cfg.key_base_tile_ry),
+            classes=[classes["type"], classes["class"]],
+        )
+
+    def _draw_rect_styled(self, p: Point, d: Tuple[float, float], classes: Dict[str, str]) -> None:
+        # get key dimension
+        w, h = d
         # check style
-        if self.cfg.keys_style == 'base':
-            # draw external rectangle
-            # External rectangle is composed by 2 rectangles.
-            # The first is needed to have a black background (or what you want).
-            # The second is meant to be filled with the same color of the internal rectangle with some opacity.
-            self._draw_rect(p, w - 2 * in_pad_w, h - 2 * in_pad_h, rx, ry, classes=[tp, f'{cl}-background'])
-            self._draw_rect(p, w - 2 * in_pad_w, h - 2 * in_pad_h, rx, ry, classes=[tp, f'{cl}-side'])
-
-            # draw internal rectangle
-            self._draw_rect(
-                 Point(p.x+self.cfg.key_base_tile_rel_x, p.y+self.cfg.key_base_tile_rel_y),
-                (w+self.cfg.key_base_tile_rel_w) - 2 * in_pad_w,
-                (h+self.cfg.key_base_tile_rel_h) - 2 * in_pad_h,
-                self.cfg.key_base_tile_rx,
-                self.cfg.key_base_tile_ry,
-                classes=[tp, cl]
-            )
-
+        if self.cfg.keys_style == "base":
+            self._draw_rect_style_base(p, d, classes)
         else:
             # default key style
-            self._draw_rect(p, h - 2 * in_pad_w, h - 2 * in_pad_h, rx, ry, classes=[tp, cl])
+            self._draw_rect(
+                p,
+                (w - 2 * self.cfg.inner_pad_w, h - 2 * self.cfg.inner_pad_h),
+                (self.cfg.key_rx, self.cfg.key_ry),
+                classes=[classes["type"], classes["class"]],
+            )
 
     def _get_scaling(self, width: int) -> str:
         if not self.cfg.shrink_wide_legends or width <= self.cfg.shrink_wide_legends:
@@ -159,7 +179,9 @@ class KeymapDrawer:
         )
         if r != 0:
             self.out.write(f'<g transform="rotate({r}, {p.x}, {p.y})">\n')
-        self._draw_rect_styled(p, w - 2 * self.cfg.inner_pad_w, h - 2 * self.cfg.inner_pad_h, l_key.type, "key")
+        self._draw_rect_styled(
+            p, (w - 2 * self.cfg.inner_pad_w, h - 2 * self.cfg.inner_pad_h), {"type": l_key.type, "class": "key"}
+        )
 
         tap_words = self._split_text(l_key.tap)
 
@@ -176,7 +198,7 @@ class KeymapDrawer:
             tap_words,
             key_type=l_key.type,
             legend_type="tap",
-            shift=shift
+            shift=shift,
         )
         self._draw_legend(
             p + Point(0, h / 2 - self.cfg.inner_pad_h - self.cfg.small_pad),
@@ -278,7 +300,9 @@ class KeymapDrawer:
                             self._draw_line_dendron(p, p_0 + k.pos, k.width / 3)
 
         # draw combo box with text
-        self._draw_rect(p, self.cfg.combo_w, self.cfg.combo_h, self.cfg.key_rx, self.cfg.key_ry, classes=[combo.type])
+        self._draw_rect(
+            p, (self.cfg.combo_w, self.cfg.combo_h), (self.cfg.key_rx, self.cfg.key_ry), classes=[combo.type]
+        )
 
         self._draw_legend(p, self._split_text(combo.key.tap), key_type=combo.type, legend_type="tap")
         self._draw_legend(

--- a/keymap_drawer/draw.py
+++ b/keymap_drawer/draw.py
@@ -49,7 +49,7 @@ class KeymapDrawer:
             f'width="{round(w)}" height="{round(h)}"{self._to_class_str(classes)}/>\n'
         )
 
-    def _draw_rect_style_base(self, p: Point, dim_w_h: tuple[float, float], classes: dict[str, str]) -> None:
+    def _draw_key_with_sides(self, p: Point, dim_w_h: tuple[float, float], classes: dict[str, str]) -> None:
         # get key dimension
         w, h = dim_w_h
         # draw external rectangle
@@ -59,40 +59,35 @@ class KeymapDrawer:
         # draw background rectangle
         self._draw_rect(
             p,
-            (w - 2 * self.cfg.inner_pad_w, h - 2 * self.cfg.inner_pad_h),
+            dim_w_h,
             (self.cfg.key_rx, self.cfg.key_ry),
             classes=[classes["type"], f'{classes["class"]}-background'],
         )
         # draw side rectangle
         self._draw_rect(
             p,
-            (w - 2 * self.cfg.inner_pad_w, h - 2 * self.cfg.inner_pad_h),
+            dim_w_h,
             (self.cfg.key_rx, self.cfg.key_ry),
             classes=[classes["type"], f'{classes["class"]}-side'],
         )
         # draw internal rectangle
         self._draw_rect(
             Point(p.x + self.cfg.key_sides["rel_x"], p.y + self.cfg.key_sides["rel_y"]),
-            (
-                (w + self.cfg.key_sides["rel_w"]) - 2 * self.cfg.inner_pad_w,
-                (h + self.cfg.key_sides["rel_h"]) - 2 * self.cfg.inner_pad_h,
-            ),
+            (w + self.cfg.key_sides["rel_w"], h + self.cfg.key_sides["rel_h"]),
             (self.cfg.key_sides["rx"], self.cfg.key_sides["ry"]),
             classes=[classes["type"], classes["class"]],
         )
 
     def _draw_rect_styled(self, p: Point, dim_w_h: tuple[float, float], classes: dict[str, str]) -> None:
-        # get key dimension
-        w, h = dim_w_h
         # check style
         if self.cfg.draw_key_sides:
             print()
-            self._draw_rect_style_base(p, dim_w_h, classes)
+            self._draw_key_with_sides(p, dim_w_h, classes)
         else:
             # default key style
             self._draw_rect(
                 p,
-                (w - 2 * self.cfg.inner_pad_w, h - 2 * self.cfg.inner_pad_h),
+                dim_w_h,
                 (self.cfg.key_rx, self.cfg.key_ry),
                 classes=[classes["type"], classes["class"]],
             )


### PR DESCRIPTION
Not breaking changes and backwards compatible.

Implented the possibility to change keys style. 

The style can be chosen with the `keys_style` configuration (default style is selected).

## Examples

### Default configuration with `keys_style: base`:
![default_base_keys_style](https://github.com/caksoylar/keymap-drawer/assets/39779328/6a071cf3-e3af-4da0-a5ad-0dde678a9061)

### Custom configuration omitting `keys_style`
![default_keys_style](https://github.com/caksoylar/keymap-drawer/assets/39779328/9991a451-22a9-4511-973d-ce475c953f45)

### Custom configuration with `keys_style: base`
![base_keys_style](https://github.com/caksoylar/keymap-drawer/assets/39779328/a879b409-e05d-4750-a6cd-ecb8d299d1f8)


## Configurations
### New draw configurations in config.py
``` py
    # relative position of key legend
    legend_rel_x: float = 0
    legend_rel_y: float = 0

    # change key style: default, base
    keys_style: str = 'default'

    # relative position of external key rectangle
    key_base_tile_rel_x: float = 0
    key_base_tile_rel_y: float = -2.5
    # relative dimension of internal key rectangles
    key_base_tile_rel_w: float = -12
    key_base_tile_rel_h: float = -12
    # curvature of rounded internal key rectangles
    key_base_tile_rx: float = 4.5
    key_base_tile_ry: float = 4.5
```
#### svg_style
``` css
        /* default key background styling  */
        rect.key-background, rect.held-background, rect.ghost-background {
            fill: black
        }

        /* default key styling */
        rect.key, rect.key-side {
            fill: #f6f8fa;
            stroke: #c9cccf;
            stroke-width: 1;
        }

        /* default key side styling */
        rect.key-side, rect.held-side, rect.ghost-side {
            opacity: 0.9;
        }
```
