### PR TITLE
feat: Add option to override default css rather than replace it

### DIFF
--- a/keymap_drawer/config.py
+++ b/keymap_drawer/config.py
@@ -4,7 +4,8 @@ keycode converters for parsing.
 """
 
 from textwrap import dedent
-from pydantic import BaseSettings, BaseModel
+
+from pydantic import BaseModel, BaseSettings
 
 
 class DrawConfig(BaseSettings, env_prefix="KEYMAP_", extra="ignore"):
@@ -181,6 +182,7 @@ class DrawConfig(BaseSettings, env_prefix="KEYMAP_", extra="ignore"):
         /* End Tabler Icons Cleanup */
         """
     )
+    svg_extra_style: str = ""
 
     # shrink font size for legends wider than this many chars, set to 0 to disable
     # ideal value depends on the font size defined in svg_style and width of the boxes

--- a/keymap_drawer/draw/draw.py
+++ b/keymap_drawer/draw/draw.py
@@ -4,16 +4,16 @@ keymap with layers and optionally combo definitions, then can draw an SVG
 representation of the keymap using these two.
 """
 
-from io import StringIO
-from html import escape
 from copy import deepcopy
-from typing import Sequence, Mapping, TextIO
+from html import escape
+from io import StringIO
+from typing import Mapping, Sequence, TextIO
 
-from keymap_drawer.keymap import KeymapData, LayoutKey, ComboSpec
-from keymap_drawer.physical_layout import Point, PhysicalKey, PhysicalLayout
 from keymap_drawer.config import DrawConfig
-from keymap_drawer.draw.utils import UtilsMixin
 from keymap_drawer.draw.combo import ComboDrawerMixin
+from keymap_drawer.draw.utils import UtilsMixin
+from keymap_drawer.keymap import ComboSpec, KeymapData, LayoutKey
+from keymap_drawer.physical_layout import PhysicalKey, PhysicalLayout, Point
 
 
 class KeymapDrawer(ComboDrawerMixin, UtilsMixin):
@@ -197,6 +197,7 @@ class KeymapDrawer(ComboDrawerMixin, UtilsMixin):
             'xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">\n'
         )
         self.output_stream.write(self.get_glyph_defs())
-        self.output_stream.write(f"<style>{self.cfg.svg_style}</style>\n")
+        extra_style = f"\n{self.cfg.svg_extra_style}" if self.cfg.svg_extra_style else ""
+        self.output_stream.write(f"<style>{self.cfg.svg_style}{extra_style}</style>\n")
         self.output_stream.write(self.out.getvalue())
         self.output_stream.write("</svg>\n")


### PR DESCRIPTION
Up until now, I've had to dump the config and add my custom css rules at the end of the default css rules in my config. When an update happens, I have to diff the default css rules to see what has changed. This PR adds a new config option (`svg_extra_style`) to add css rules after the default css rules rather than replacing the default css rules.