### PR TITLE
Fix invalid SVG error when using special char in layer lable

### DIFF
--- a/keymap_drawer/draw/draw.py
+++ b/keymap_drawer/draw/draw.py
@@ -114,7 +114,7 @@ class KeymapDrawer(ComboDrawerMixin, UtilsMixin):
 
             # per-layer class group
             self.out.write(
-                f'<g transform="translate({round(p.x + outer_pad_w)}, {round(p.y)})" class="layer-{name}">\n'
+                f'<g transform="translate({round(p.x + outer_pad_w)}, {round(p.y)})" class="layer-{escape(name)}">\n'
             )
 
             # draw layer name


### PR DESCRIPTION
Hi @caksoylar,

This is a super quick PR to fix an issue with string escape. I have a layer called `<^v>` (my nav layer), and it causes issues with the draw function. 

The draw function would not see any error, but the resulting SVG is invalid. This is the error
```
error on line 2462 at column 50: Unescaped '<' not allowed in attributes values
```

The fix was super quick, I just used your pre-existing `escape` function to escape the name. I tested it and it works as expected.

One thing to note: I couldn't see where the layer styling class is actually used 🤔. So it is now correctly escaped, but it appears the classname isn't used anywhere. So, either it is indeed not used, and that's fine. Or it _is_ used somewhere and I missed it. In which case, let me know where and I'll update the PR.

Thank you for your work 🙏