### PR TITLE
Add option to show key under transparent keys, and find the layer name during parsing

### DIFF
--- a/keymap_drawer/config.py
+++ b/keymap_drawer/config.py
@@ -236,7 +236,10 @@ class ParseConfig(BaseSettings, env_prefix="KEYMAP_", extra="ignore"):
 
     # legend to output for transparent keys
     trans_legend: str | dict = {"t": "▽", "type": "trans"}
-
+    
+    # whether to show the keycode this transparent key will activate
+    trans_show_lower_key: bool = False
+    
     # rather than only marking the first sequence of key positions to reach a layer as "held",
     # mark all of the sequences to reach a given layer. this is disabled by default because it
     # creates ambiguity: you cannot tell if *all* the marked keys need to be held down while a

--- a/keymap_drawer/config.py
+++ b/keymap_drawer/config.py
@@ -236,10 +236,10 @@ class ParseConfig(BaseSettings, env_prefix="KEYMAP_", extra="ignore"):
 
     # legend to output for transparent keys
     trans_legend: str | dict = {"t": "▽", "type": "trans"}
-    
+
     # whether to show the keycode this transparent key will activate
     trans_show_lower_key: bool = False
-    
+
     # rather than only marking the first sequence of key positions to reach a layer as "held",
     # mark all of the sequences to reach a given layer. this is disabled by default because it
     # creates ambiguity: you cannot tell if *all* the marked keys need to be held down while a

--- a/keymap_drawer/keymap.py
+++ b/keymap_drawer/keymap.py
@@ -43,7 +43,7 @@ class LayoutKey(BaseModel, allow_population_by_field_name=True):
         if no_tapstr or not set(dict_repr.keys()).issubset({"t", "tap"}):
             return dict_repr
         return dict_repr.get("t") or dict_repr.get("tap", "")
-    
+
     def __hash__(self):
         return hash((self.tap, self.hold, self.shifted, self.type))
 

--- a/keymap_drawer/keymap.py
+++ b/keymap_drawer/keymap.py
@@ -43,6 +43,9 @@ class LayoutKey(BaseModel, allow_population_by_field_name=True):
         if no_tapstr or not set(dict_repr.keys()).issubset({"t", "tap"}):
             return dict_repr
         return dict_repr.get("t") or dict_repr.get("tap", "")
+    
+    def __hash__(self):
+        return hash((self.tap, self.hold, self.shifted, self.type))
 
 
 class ComboSpec(BaseModel, allow_population_by_field_name=True):

--- a/keymap_drawer/parse/parse.py
+++ b/keymap_drawer/parse/parse.py
@@ -25,7 +25,7 @@ class KeymapParser(ABC):  # pylint: disable=too-many-instance-attributes
         self.columns = columns if columns is not None else 0
         self.layer_names: list[str] | None = layer_names
         self.base_keymap = base_keymap
-        self.layer_activated_from: dict[int, set[int]] = {}  # layer to key positions
+        self.layer_activated_from: dict[int, set[tuple[int, int]]] = {}  # layer to [layer index, key position] from keys
         self.conditional_layers: dict[int, list[int]] = {}  # then-layer to if-layers mapping
         self.trans_key = LayoutKey.from_key_spec(self.cfg.trans_legend)
         self.raw_binding_map = self.cfg.raw_binding_map.copy()
@@ -53,7 +53,9 @@ class KeymapParser(ABC):  # pylint: disable=too-many-instance-attributes
 
         if to_layer not in self.layer_activated_from:
             self.layer_activated_from[to_layer] = set()
-        self.layer_activated_from[to_layer] |= set(key_positions)  # came here through these key(s)
+            
+        for from_layer in from_layers:
+            self.layer_activated_from[to_layer] |= set((from_layer, key_pos) for key_pos in key_positions)
 
         # also consider how the layer we are coming from got activated
         for from_layer in from_layers:
@@ -69,7 +71,7 @@ class KeymapParser(ABC):  # pylint: disable=too-many-instance-attributes
 
         # assign held keys
         for layer_index, activating_keys in self.layer_activated_from.items():
-            for key_idx in activating_keys:
+            for (_, key_idx) in activating_keys:
                 key = layers[self.layer_names[layer_index]][key_idx]
                 if key == self.trans_key:  # clear legend if it is a transparent key
                     layers[self.layer_names[layer_index]][key_idx] = LayoutKey(type="held")
@@ -77,7 +79,42 @@ class KeymapParser(ABC):  # pylint: disable=too-many-instance-attributes
                     key.type = "held"
 
         return layers
+    
+    def fill_trans_keys(self, layers: dict[str, list[LayoutKey]]) -> dict[str, list[LayoutKey]]:
+        """Fill in transparent keys with the legend of the key that is underneath."""
+        
+        for layer_name, keys in layers.items():
+            layer_idx = self.layer_names.index(layer_name)
+            for key_idx, key in enumerate(keys):
+                if key == self.trans_key:
+                    lower_keys = self._find_lower_keys(layer_idx, key_idx, layers)
+                    # usually there should only be one lower key, but if you can get to this layer from multiple different layers
+                    # that have this key defined, show all of them
+                    if len(lower_keys) > 0:
+                        layers[layer_name][key_idx] = LayoutKey(
+                            tap="|".join(key.tap for key in lower_keys),
+                            hold="|".join(key.hold for key in lower_keys),
+                            shifted="|".join(key.shifted for key in lower_keys),
+                            type=self.trans_key.type
+                        )
+        return layers
 
+    def _find_lower_keys(self, layer, key, layers: dict[str, list[LayoutKey]]) -> set[LayoutKey]:
+        lower_keys = set()
+        activated_from_keys = self.layer_activated_from.get(layer, set())
+
+        for (layer_idx, _) in activated_from_keys:
+            layer_name = self.layer_names[layer_idx]
+            from_layer = layers[layer_name]
+            lower_key = from_layer[key]
+            if lower_key == self.trans_key:
+                lower_keys |= self._find_lower_keys(layer_idx, key, layers)
+            else:
+                lower_keys.add(lower_key)
+                
+        
+        return lower_keys
+        
     def _parse(self, in_str: str, file_name: str | None = None) -> tuple[dict, KeymapData]:
         raise NotImplementedError
 

--- a/keymap_drawer/parse/qmk.py
+++ b/keymap_drawer/parse/qmk.py
@@ -49,12 +49,13 @@ class QmkJsonParser(KeymapParser):
             if self._prefix_re is not None:
                 key = self._prefix_re.sub("", key)
             return LayoutKey.from_key_spec(self.cfg.qmk_keycode_map.get(key, key.replace("_", " ")))
-        
+
         def parse_layer(layer: str) -> int:
+            assert self.layer_names is not None
+
             if layer.isdigit():
                 return int(layer)
-            else:
-                return self.layer_names.index(layer)
+            return self.layer_names.index(layer)
 
         if m := self._trans_re.fullmatch(key_str):  # transparent
             return self.trans_key
@@ -117,7 +118,7 @@ class QmkJsonParser(KeymapParser):
         }
 
         layers = self.add_held_keys(layers)
-        
+
         if self.cfg.trans_show_lower_key:
             layers = self.fill_trans_keys(layers)
 

--- a/keymap_drawer/parse/qmk.py
+++ b/keymap_drawer/parse/qmk.py
@@ -109,6 +109,10 @@ class QmkJsonParser(KeymapParser):
         }
 
         layers = self.add_held_keys(layers)
+        
+        if self.cfg.trans_show_lower_key:
+            layers = self.fill_trans_keys(layers)
+
         keymap_data = KeymapData(layers=layers, layout=None, config=None)
 
         return layout, keymap_data

--- a/keymap_drawer/parse/zmk.py
+++ b/keymap_drawer/parse/zmk.py
@@ -221,7 +221,7 @@ class ZmkKeymapParser(KeymapParser):
         layers = self._get_layers(dts)
         combos = self._get_combos(dts)
         layers = self.add_held_keys(layers)
-        
+
         if self.cfg.trans_show_lower_key:
             layers = self.fill_trans_keys(layers)
 

--- a/keymap_drawer/parse/zmk.py
+++ b/keymap_drawer/parse/zmk.py
@@ -221,6 +221,9 @@ class ZmkKeymapParser(KeymapParser):
         layers = self._get_layers(dts)
         combos = self._get_combos(dts)
         layers = self.add_held_keys(layers)
+        
+        if self.cfg.trans_show_lower_key:
+            layers = self.fill_trans_keys(layers)
 
         keymap_data = KeymapData(layers=layers, combos=combos, layout=None, config=None)
 


### PR DESCRIPTION
Hi, I needed these two features and implemented them. I think others might want them as well

* Added an option to show the keys under transparent keys. Now you can see what key will actually be sent when that transparent key is pressed. If there are multiple ways to get to a layer, and the transparent key could send different things based on the current path, then it will show all the possibilities (I imagine this would be pretty rare, my layout does not do this). The style of these is still set to trans, so they can be styled as such.
* During QMK parsing, it will find the layer names from their indexes. This way parsing qmk c2json files will show the correct destination layer for MO/LT/etc.

Let me know if you have any questions!