### PR TITLE
Add path argument for <keymap>.json layout file

### DIFF
--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -20,7 +20,7 @@ on:
         required: false
         type: string
       json_path:
-        description: 'Path to the <keymap>.json layout configuration file, ignored if non-existent'
+        description: 'Path containing <keymap>.json physical layout description files, ignored if non-existent'
         default: 'config'
         required: false
         type: string

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -103,10 +103,9 @@ jobs:
               echo "INFO:   got extra draw args: $draw_args"
 
               json_path="${{ inputs.json_path }}"
-              [ -e "$json_path" ] && json_dir="$json_path"
-              if [ -f "${json_dir:-config}/${keyboard}.json" ]; then
-                  echo "INFO:   found ${json_dir:-config}/${keyboard}.json";
-                  draw_args+=" -j ${json_dir:-config}/${keyboard}.json"
+              if [ -f "$json_path/${keyboard}.json" ]; then
+                  echo "INFO:   found $json_path/${keyboard}.json";
+                  draw_args+=" -j $json_path/${keyboard}.json"
               fi
 
               keymap "${config_arg[@]}" parse -z "$keymap_file" $parse_args >"${{ inputs.output_folder }}/$keyboard.yaml" \

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -103,7 +103,7 @@ jobs:
               echo "INFO:   got extra draw args: $draw_args"
 
               json_path="${{ inputs.json_path }}"
-              [ -e "$json_path" ] && json_dir="$json_path")
+              [ -e "$json_path" ] && json_dir="$json_path"
               if [ -f "${json_dir:-config}/${keyboard}.json" ]; then
                   echo "INFO:   found ${json_dir:-config}/${keyboard}.json";
                   draw_args+=" -j ${json_dir:-config}/${keyboard}.json"

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -5,43 +5,48 @@ on:
   workflow_call:
     inputs:
       keymap_patterns:
-        description: "Path specification for keymaps to be parsed"
-        default: "config/*.keymap"
+        description: 'Path specification for keymaps to be parsed'
+        default: 'config/*.keymap'
         required: false
         type: string
       config_path:
-        description: "Path to the keymap-drawer configuration file, ignored if non-existent"
-        default: "keymap_drawer.config.yaml"
+        description: 'Path to the keymap-drawer configuration file, ignored if non-existent'
+        default: 'keymap_drawer.config.yaml'
         required: false
         type: string
       output_folder:
-        description: "Output folder for SVG and YAML files"
-        default: "keymap-drawer"
+        description: 'Output folder for SVG and YAML files'
+        default: 'keymap-drawer'
+        required: false
+        type: string
+      json_path:
+        description: 'Path to the <keymap>.json layout configuration file, ignored if non-existent'
+        default: 'config'
         required: false
         type: string
       parse_args:
         description: "Map of keyboard names to extra `keymap parse` args, e.g. `corne:'--layer-names Def Lwr Rse Fun'`"
-        default: ""
+        default: ''
         required: false
         type: string
       draw_args:
         description: "Map of keyboard names to extra `keymap draw` args, e.g. `corne:'-k corne_rotated -l LAYOUT_split_3x5_3'`"
-        default: ""
+        default: ''
         required: false
         type: string
       commit_message:
-        description: "Commit message for updated images. Ignored if `amend_commit` is `true`."
-        default: "keymap-drawer render"
+        description: 'Commit message for updated images. Ignored if `amend_commit` is `true`.'
+        default: 'keymap-drawer render'
         required: false
         type: string
       amend_commit:
-        description: "Whether to amend the last commit instead of creating a new one. Make sure you understand the implications of rewriting the branch history if you use this option!"
+        description: 'Whether to amend the last commit instead of creating a new one. Make sure you understand the implications of rewriting the branch history if you use this option!'
         default: false
         required: false
         type: boolean
       install_branch:
-        description: "Install keymap-drawer from a git branch, use empty for pypi release (default)"
-        default: ""
+        description: 'Install keymap-drawer from a git branch, use empty for pypi release (default)'
+        default: ''
         required: false
         type: string
 
@@ -97,9 +102,11 @@ jobs:
               draw_args=$(get_args "${{ inputs.draw_args }}" "$keyboard")
               echo "INFO:   got extra draw args: $draw_args"
 
-              if [ -f "config/${keyboard}.json" ]; then
-                  echo "INFO:   found config/${keyboard}.json";
-                  draw_args+=" -j config/${keyboard}.json"
+              json_path="${{ inputs.json_path }}"
+              [ -e "$json_path" ] && json_dir="$json_path")
+              if [ -f "${json_dir:-config}/${keyboard}.json" ]; then
+                  echo "INFO:   found ${json_dir:-config}/${keyboard}.json";
+                  draw_args+=" -j ${json_dir:-config}/${keyboard}.json"
               fi
 
               keymap "${config_arg[@]}" parse -z "$keymap_file" $parse_args >"${{ inputs.output_folder }}/$keyboard.yaml" \
@@ -116,13 +123,13 @@ jobs:
       - name: Commit updated images
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          file_pattern: "${{ inputs.output_folder }}/*.svg ${{ inputs.output_folder }}/*.yaml"
+          file_pattern: '${{ inputs.output_folder }}/*.svg ${{ inputs.output_folder }}/*.yaml'
           # So the previous commit is amended instead of creating a new one when desired
           # See:
           # - https://github.com/stefanzweifel/git-auto-commit-action#using---amend-and---no-edit-as-commit-options
           # - https://github.com/stefanzweifel/git-auto-commit-action/issues/159#issuecomment-845347950
           # - https://github.com/actions/checkout
-          commit_message: "${{ (inputs.amend_commit == true && steps.last_commit_message.outputs.msg) || inputs.commit_message }}"
+          commit_message: '${{ (inputs.amend_commit == true && steps.last_commit_message.outputs.msg) || inputs.commit_message }}'
           commit_options: "${{ (inputs.amend_commit == true && '--amend --no-edit') || '' }}"
           push_options: "${{ (inputs.amend_commit == true && '--force-with-lease') || '' }}"
           skip_fetch: ${{ inputs.amend_commit == true }}


### PR DESCRIPTION
Hi Cem,

I have created a small patch to make it possible that the path to the layout file for a keyboard's keymap can be specified in the arguments to the `draw-zmk.yaml` workflow.

Unfortunately my linter automatically reformatted all double quotes... I am sorry about that, just saw that. Also I was unsure, whether you wanted perhaps a different implementation, like not a directory, but a full path to the .json file or so. Let me know, if I should change the PR.

Thanks a lot for the drawer - I hate it, when I have to manually generate artwork, whenever a technical document changes...

BTW: the repo where it is used is here: https://github.com/michaelrommel/zmk-config

```

├── README.md
├── build.yaml
├── config
│   ├── boards
│   │   └── arm
│   │       └── nightliner
│   │           ├── Kconfig
│   │           ├── Kconfig.board
│   │           ├── Kconfig.defconfig
│   │           ├── board.cmake
│   │           ├── nightliner-pinctrl.dtsi
│   │           ├── nightliner.dtsi
│   │           ├── nightliner.keymap
│   │           ├── nightliner.yaml
│   │           ├── nightliner.zmk.yml
│   │           ├── nightliner_left.dts
│   │           ├── nightliner_left_defconfig
│   │           ├── nightliner_right.dts
│   │           └── nightliner_right_defconfig
│   └── west.yml
├── images
│   ├── keymap_drawer.config.yaml
│   ├── nightliner.json
│   ├── nightliner.png
│   ├── nightliner.svg
│   ├── nightliner.yaml
│   ├── nightliner_keypositions.png
│   └── nightliner_prev.yaml
├── scripts
│   └── create_svg.sh
├── tags
└── zephyr
    └── module.yml

```