### PR TITLE
Add an artifact as destination option for using in subsequent jobs

### DIFF
--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -54,6 +54,11 @@ on:
         default: 'commit'
         required: false
         type: string
+      artifactname:
+        description: 'Define the name the drawings are stored as an artifact'
+        default: 'drawings'
+        required: false
+        type: string
     outputs:
       drawings-id:
         description: 'Archive with keymap in yaml and drawing in svg formats'
@@ -155,7 +160,7 @@ jobs:
         id: artifact-upload-step
         uses: actions/upload-artifact@v4
         with:
-          name: drawings
+          name: '${{ inputs.artifactname }}'
           path: |
             ${{ join(fromJSON(steps.draw.outputs.OUTPUTS), '
             ') }}

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -121,7 +121,7 @@ jobs:
               if [[ ${FIRST} -ne 1 ]]; then
                 OUTPUTS="${OUTPUTS},"
               fi
-              OUTPUTS="${OUTPUTS}\"$keyboard.yaml\",\"$keyboard.svg\""
+              OUTPUTS="${OUTPUTS}\"${{ inputs.output_folder }}/$keyboard.yaml\",\"${{ inputs.output_folder }}/$keyboard.svg\""
           done
           echo "OUTPUTS=[${OUTPUTS}]" >> $GITHUB_OUTPUT
 
@@ -151,6 +151,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: drawings
-          path: |-
+          path: |
             ${{ join(fromJSON(steps.draw.outputs.OUTPUTS), '
             ') }}

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -49,6 +49,11 @@ on:
         default: ''
         required: false
         type: string
+      destination:
+        description: 'Add the output files to a commit, as artifacts or both, values: `commit`, `artifact`, `both`'
+        default: 'commit'
+        required: false
+        type: string
 
 jobs:
   draw:
@@ -75,6 +80,7 @@ jobs:
         run: python3 -m pip install "git+https://github.com/caksoylar/keymap-drawer.git@${{ inputs.install_branch }}"
 
       - name: Draw keymaps
+        id: draw
         run: |
           get_args() {
               local keyboard=$2
@@ -93,6 +99,7 @@ jobs:
 
           config_path="${{ inputs.config_path }}"
           [ -e "$config_path" ] && config_arg=(-c "$config_path") || config_arg=()
+          FIRST=1
           for keymap_file in ${{ inputs.keymap_patterns }}; do
               keyboard=$(basename -s .keymap "$keymap_file")
               echo "INFO: drawing for $keyboard"
@@ -111,15 +118,21 @@ jobs:
               keymap "${config_arg[@]}" parse -z "$keymap_file" $parse_args >"${{ inputs.output_folder }}/$keyboard.yaml" \
               && keymap "${config_arg[@]}" draw "${{ inputs.output_folder }}/$keyboard.yaml" $draw_args >"${{ inputs.output_folder }}/$keyboard.svg" \
               || echo "ERROR: parsing or drawing failed for $keyboard!"
+              if [[ ${FIRST} -ne 1 ]]; then
+                OUTPUTS="${OUTPUTS},"
+              fi
+              OUTPUTS="${OUTPUTS}\"$keyboard.yaml\",\"$keyboard.svg\""
           done
+          echo "OUTPUTS=[${OUTPUTS}]" >> $GITHUB_OUTPUT
 
       - name: Get last commit message
         id: last_commit_message
-        if: inputs.amend_commit == true
+        if: inputs.amend_commit == true && (inputs.destination == 'commit || inputs.destination == 'both')
         run: |
           echo "msg=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT
 
       - name: Commit updated images
+        if: inputs.destination == 'commit || inputs.destination == 'both'
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           file_pattern: '${{ inputs.output_folder }}/*.svg ${{ inputs.output_folder }}/*.yaml'
@@ -132,3 +145,10 @@ jobs:
           commit_options: "${{ (inputs.amend_commit == true && '--amend --no-edit') || '' }}"
           push_options: "${{ (inputs.amend_commit == true && '--force-with-lease') || '' }}"
           skip_fetch: ${{ inputs.amend_commit == true }}
+
+      - name: Artifact upload
+        id: artifact-upload-step
+        uses: actions/upload-artifact@v4
+        with:
+          name: drawings
+          path: ${{ fromJSON(steps.draw.outputs.OUTPUTS) }}

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -127,12 +127,12 @@ jobs:
 
       - name: Get last commit message
         id: last_commit_message
-        if: inputs.amend_commit == true && (inputs.destination == 'commit || inputs.destination == 'both')
+        if: inputs.amend_commit == true && (inputs.destination == 'commit' || inputs.destination == 'both')
         run: |
           echo "msg=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT
 
       - name: Commit updated images
-        if: ( inputs.destination == 'commit || inputs.destination == 'both' )
+        if: ( inputs.destination == 'commit' || inputs.destination == 'both' )
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           file_pattern: '${{ inputs.output_folder }}/*.svg ${{ inputs.output_folder }}/*.yaml'

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -151,5 +151,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: drawings
-          path: |
-            ${{ fromJSON(steps.draw.outputs.OUTPUTS) }}
+          path: |-
+            ${{ join(fromJSON(steps.draw.outputs.OUTPUTS), '
+            ') }}

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -54,6 +54,8 @@ on:
         default: 'commit'
         required: false
         type: string
+    outputs:
+      drawings-id: ${{ jobs.draw.outputs.drawings-id }}
 
 jobs:
   draw:

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -60,15 +60,15 @@ on:
         required: false
         type: string
     outputs:
-      drawings-id:
+      drawings:
         description: 'Archive with keymap in YAML and drawing in SVG formats'
-        value: ${{ jobs.draw.outputs.drawings-id }}
+        value: ${{ jobs.draw.outputs.drawings }}
 
 jobs:
   draw:
     runs-on: ubuntu-latest
     outputs:
-      drawings-id: ${{ steps.artifact-upload-step.outputs.artifact-id }}
+      drawings: ${{ steps.artifact-upload-step.outputs.artifact-id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -105,11 +105,12 @@ jobs:
               done
           }
 
+          IFS=','
+          declare -a DRAWINGS
           mkdir -p "${{ inputs.output_folder }}"
 
           config_path="${{ inputs.config_path }}"
           [ -e "$config_path" ] && config_arg=(-c "$config_path") || config_arg=()
-          FIRST=1
           for keymap_file in ${{ inputs.keymap_patterns }}; do
               keyboard=$(basename -s .keymap "$keymap_file")
               echo "INFO: drawing for $keyboard"
@@ -128,12 +129,9 @@ jobs:
               keymap "${config_arg[@]}" parse -z "$keymap_file" $parse_args >"${{ inputs.output_folder }}/$keyboard.yaml" \
               && keymap "${config_arg[@]}" draw "${{ inputs.output_folder }}/$keyboard.yaml" $draw_args >"${{ inputs.output_folder }}/$keyboard.svg" \
               || echo "ERROR: parsing or drawing failed for $keyboard!"
-              if [[ ${FIRST} -ne 1 ]]; then
-                OUTPUTS="${OUTPUTS},"
-              fi
-              OUTPUTS="${OUTPUTS}\"${{ inputs.output_folder }}/$keyboard.yaml\",\"${{ inputs.output_folder }}/$keyboard.svg\""
+              DRAWINGS+=(\"${{ inputs.output_folder }}/$keyboard.yaml\" \"${{ inputs.output_folder }}/$keyboard.svg\")
           done
-          echo "OUTPUTS=[${OUTPUTS}]" >> $GITHUB_OUTPUT
+          echo "DRAWINGS=[${DRAWINGS[*]}]" >> $GITHUB_OUTPUT
 
       - name: Get last commit message
         id: last_commit_message
@@ -163,5 +161,5 @@ jobs:
         with:
           name: '${{ inputs.artifactname }}'
           path: |
-            ${{ join(fromJSON(steps.draw.outputs.OUTPUTS), '
+            ${{ join(fromJSON(steps.draw.outputs.DRAWINGS), '
             ') }}

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -103,10 +103,9 @@ jobs:
               echo "INFO:   got extra draw args: $draw_args"
 
               json_path="${{ inputs.json_path }}"
-              [ -e "$json_path" ] && json_dir="$json_path"
-              if [ -f "${json_dir:-config}/${keyboard}.json" ]; then
-                  echo "INFO:   found ${json_dir:-config}/${keyboard}.json";
-                  draw_args+=" -j ${json_dir:-config}/${keyboard}.json"
+              if [ -f "$json_path/${keyboard}.json" ]; then
+                  echo "INFO:   found $json_path/${keyboard}.json";
+                  draw_args+=" -j $json_path/${keyboard}.json"
               fi
 
               keymap "${config_arg[@]}" parse -z "$keymap_file" $parse_args >"${{ inputs.output_folder }}/$keyboard.yaml" \

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -151,4 +151,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: drawings
-          path: ${{ fromJSON(steps.draw.outputs.OUTPUTS) }}
+          path: |
+            ${{ fromJSON(steps.draw.outputs.OUTPUTS) }}

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -105,7 +105,6 @@ jobs:
               done
           }
 
-          IFS=','
           declare -a DRAWINGS
           mkdir -p "${{ inputs.output_folder }}"
 
@@ -131,8 +130,10 @@ jobs:
               || echo "ERROR: parsing or drawing failed for $keyboard!"
               DRAWINGS+=(\"${{ inputs.output_folder }}/$keyboard.yaml\" \"${{ inputs.output_folder }}/$keyboard.svg\")
           done
+          IFS=','
           echo "DRAWINGS=[${DRAWINGS[*]}]" >> $GITHUB_OUTPUT
-
+          unset IFS
+          
       - name: Get last commit message
         id: last_commit_message
         if: inputs.amend_commit == true && (inputs.destination == 'commit' || inputs.destination == 'both')

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -132,7 +132,7 @@ jobs:
           echo "msg=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT
 
       - name: Commit updated images
-        if: inputs.destination == 'commit || inputs.destination == 'both'
+        if: ( inputs.destination == 'commit || inputs.destination == 'both' )
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           file_pattern: '${{ inputs.output_folder }}/*.svg ${{ inputs.output_folder }}/*.yaml'

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -103,7 +103,7 @@ jobs:
               echo "INFO:   got extra draw args: $draw_args"
 
               json_path="${{ inputs.json_path }}"
-              [ -e "$json_path" ] && json_dir="$json_path")
+              [ -e "$json_path" ] && json_dir="$json_path"
               if [ -f "${json_dir:-config}/${keyboard}.json" ]; then
                   echo "INFO:   found ${json_dir:-config}/${keyboard}.json";
                   draw_args+=" -j ${json_dir:-config}/${keyboard}.json"

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -5,43 +5,48 @@ on:
   workflow_call:
     inputs:
       keymap_patterns:
-        description: "Path specification for keymaps to be parsed"
-        default: "config/*.keymap"
+        description: 'Path specification for keymaps to be parsed'
+        default: 'config/*.keymap'
         required: false
         type: string
       config_path:
-        description: "Path to the keymap-drawer configuration file, ignored if non-existent"
-        default: "keymap_drawer.config.yaml"
+        description: 'Path to the keymap-drawer configuration file, ignored if non-existent'
+        default: 'keymap_drawer.config.yaml'
         required: false
         type: string
       output_folder:
-        description: "Output folder for SVG and YAML files"
-        default: "keymap-drawer"
+        description: 'Output folder for SVG and YAML files'
+        default: 'keymap-drawer'
+        required: false
+        type: string
+      json_path:
+        description: 'Path to the <keymap>.json layout configuration file, ignored if non-existent'
+        default: 'config'
         required: false
         type: string
       parse_args:
         description: "Map of keyboard names to extra `keymap parse` args, e.g. `corne:'--layer-names Def Lwr Rse Fun'`"
-        default: ""
+        default: ''
         required: false
         type: string
       draw_args:
         description: "Map of keyboard names to extra `keymap draw` args, e.g. `corne:'-k corne_rotated -l LAYOUT_split_3x5_3'`"
-        default: ""
+        default: ''
         required: false
         type: string
       commit_message:
-        description: "Commit message for updated images. Ignored if `amend_commit` is `true`."
-        default: "keymap-drawer render"
+        description: 'Commit message for updated images. Ignored if `amend_commit` is `true`.'
+        default: 'keymap-drawer render'
         required: false
         type: string
       amend_commit:
-        description: "Whether to amend the last commit instead of creating a new one. Make sure you understand the implications of rewriting the branch history if you use this option!"
+        description: 'Whether to amend the last commit instead of creating a new one. Make sure you understand the implications of rewriting the branch history if you use this option!'
         default: false
         required: false
         type: boolean
       install_branch:
-        description: "Install keymap-drawer from a git branch, use empty for pypi release (default)"
-        default: ""
+        description: 'Install keymap-drawer from a git branch, use empty for pypi release (default)'
+        default: ''
         required: false
         type: string
 
@@ -97,9 +102,11 @@ jobs:
               draw_args=$(get_args "${{ inputs.draw_args }}" "$keyboard")
               echo "INFO:   got extra draw args: $draw_args"
 
-              if [ -f "config/${keyboard}.json" ]; then
-                  echo "INFO:   found config/${keyboard}.json";
-                  draw_args+=" -j config/${keyboard}.json"
+              json_path="${{ inputs.json_path }}"
+              [ -e "$json_path" ] && json_dir="$json_path")
+              if [ -f "${json_dir:-config}/${keyboard}.json" ]; then
+                  echo "INFO:   found ${json_dir:-config}/${keyboard}.json";
+                  draw_args+=" -j ${json_dir:-config}/${keyboard}.json"
               fi
 
               keymap "${config_arg[@]}" parse -z "$keymap_file" $parse_args >"${{ inputs.output_folder }}/$keyboard.yaml" \
@@ -116,13 +123,13 @@ jobs:
       - name: Commit updated images
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          file_pattern: "${{ inputs.output_folder }}/*.svg ${{ inputs.output_folder }}/*.yaml"
+          file_pattern: '${{ inputs.output_folder }}/*.svg ${{ inputs.output_folder }}/*.yaml'
           # So the previous commit is amended instead of creating a new one when desired
           # See:
           # - https://github.com/stefanzweifel/git-auto-commit-action#using---amend-and---no-edit-as-commit-options
           # - https://github.com/stefanzweifel/git-auto-commit-action/issues/159#issuecomment-845347950
           # - https://github.com/actions/checkout
-          commit_message: "${{ (inputs.amend_commit == true && steps.last_commit_message.outputs.msg) || inputs.commit_message }}"
+          commit_message: '${{ (inputs.amend_commit == true && steps.last_commit_message.outputs.msg) || inputs.commit_message }}'
           commit_options: "${{ (inputs.amend_commit == true && '--amend --no-edit') || '' }}"
           push_options: "${{ (inputs.amend_commit == true && '--force-with-lease') || '' }}"
           skip_fetch: ${{ inputs.amend_commit == true }}

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -55,7 +55,9 @@ on:
         required: false
         type: string
     outputs:
-      drawings-id: ${{ jobs.draw.outputs.drawings-id }}
+      drawings-id:
+        description: 'Archive with keymap in yaml and drawing in svg formats'
+        value: ${{ jobs.draw.outputs.drawings-id }}
 
 jobs:
   draw:

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -160,7 +160,7 @@ jobs:
         if: ( inputs.destination == 'artifact' || inputs.destination == 'both' )
         uses: actions/upload-artifact@v4
         with:
-          name: '${{ inputs.artifactname }}'
+          name: '${{ inputs.artifact_name }}'
           path: |
             ${{ join(fromJSON(steps.draw.outputs.DRAWINGS), '
             ') }}

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -54,14 +54,14 @@ on:
         default: 'commit'
         required: false
         type: string
-      artifactname:
-        description: 'Define the name the drawings are stored as an artifact'
+      artifact_name:
+        description: 'Name of the produced artifact containing SVG and YAML outputs. Ignored if `destination` is `commit`.'
         default: 'drawings'
         required: false
         type: string
     outputs:
       drawings-id:
-        description: 'Archive with keymap in yaml and drawing in svg formats'
+        description: 'Archive with keymap in YAML and drawing in SVG formats'
         value: ${{ jobs.draw.outputs.drawings-id }}
 
 jobs:
@@ -158,6 +158,7 @@ jobs:
 
       - name: Artifact upload
         id: artifact-upload-step
+        if: ( inputs.destination == 'artifact' || inputs.destination == 'both' )
         uses: actions/upload-artifact@v4
         with:
           name: '${{ inputs.artifactname }}'

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -58,7 +58,8 @@ on:
 jobs:
   draw:
     runs-on: ubuntu-latest
-
+    outputs:
+      drawings-id: ${{ steps.artifact-upload-step.outputs.artifact-id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds the functionality to add in addition to a commit or as alternative an artifact where the generated svg and yaml files are stored.

The workflow outputs the artifact-id as well as let the user define the name of the artifacts zip file.