### PR TITLE
update tabler url

### DIFF
--- a/keymap_drawer/config.py
+++ b/keymap_drawer/config.py
@@ -209,7 +209,7 @@ class DrawConfig(BaseSettings, env_prefix="KEYMAP_", extra="ignore"):
     # mapping of sources to (possibly templated) URLs for fetching SVG glyphs
     # e.g. `$$material:settings$$` will use the value for `material` and replace `{}` with `settings`
     glyph_urls: dict[str, str] = {
-        "tabler": "https://unpkg.com/@tabler/icons/icons/{}.svg",
+        "tabler": "https://unpkg.com/@tabler/icons/icons/outline/{}.svg",
         "mdi": "https://raw.githubusercontent.com/Templarian/MaterialDesign-SVG/master/svg/{}.svg",
         "mdil": "https://raw.githubusercontent.com/Pictogrammers/MaterialDesignLight/master/svg/{}.svg",
         "material": "https://fonts.gstatic.com/s/i/short-term/release/materialsymbolsoutlined/{}/default/48px.svg",


### PR DESCRIPTION
change the url path to comply with latest changes of the tabler structure.

It looks like, they changed it after [2.47.0](https://unpkg.com/browse/@tabler/icons@2.47.0/icons/)

This change will close #78 