### PR TITLE
feat: Add parsing for tap-toggle layers

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -250,6 +250,14 @@ _Type:_ `str`
 
 _Default:_ `"toggle"`
 
+#### `tap_toggle_label`
+
+Display text to place in hold field for tap-toggle (TT) keys.
+
+_Type:_ `str`
+
+_Default:_ `"tap-toggle"`
+
 #### `trans_legend`
 
 Legend to output for transparent keys.[^2]

--- a/keymap_drawer/config.py
+++ b/keymap_drawer/config.py
@@ -244,6 +244,9 @@ class ParseConfig(BaseSettings, env_prefix="KEYMAP_", extra="ignore"):
     # display text to place in hold field for toggled keys
     toggle_label: str = "toggle"
 
+    # display text to place in hold field for toggled keys
+    tap_toggle_label: str = "tap-toggle"
+
     # legend to output for transparent keys
     trans_legend: str | dict = {"t": "▽", "type": "trans"}
 

--- a/keymap_drawer/parse/qmk.py
+++ b/keymap_drawer/parse/qmk.py
@@ -20,6 +20,7 @@ class QmkJsonParser(KeymapParser):
     _lt_re = re.compile(r"LT\((\d+), *(\S+)\)")
     _osm_re = re.compile(r"OSM\(MOD_(\S+)\)")
     _osl_re = re.compile(r"OSL\((\d+)\)")
+    _tt_re = re.compile(r"TT\((\d+)\)")
 
     def __init__(
         self,
@@ -77,6 +78,10 @@ class QmkJsonParser(KeymapParser):
             to_layer = int(m.group(1).strip())
             self.update_layer_activated_from([current_layer], to_layer, key_positions)
             return LayoutKey(tap=self.layer_names[to_layer], hold=self.cfg.sticky_label)
+        if m := self._tt_re.fullmatch(key_str):  # tap-toggle layer
+            to_layer = int(m.group(1).strip())
+            self.update_layer_activated_from([current_layer], to_layer, key_positions)
+            return LayoutKey(tap=self.layer_names[to_layer], hold=self.cfg.tap_toggle_label)
         return mapped(key_str)
 
     def _parse(self, in_str: str, file_name: str | None = None) -> tuple[dict, KeymapData]:


### PR DESCRIPTION
Noticed that QMK's [tap-toggle](https://github.com/qmk/qmk_firmware/blob/master/docs/feature_layers.md) layers (`TT(layer)`) weren't being parsed