### PR TITLE
Add Docker image for the CLI

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,10 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+        base: ["", "-alpine", "-slim"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,5 +34,7 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:${{ steps.get_version.outputs.VERSION }}
-            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ steps.get_version.outputs.VERSION }}${{ matrix.base }}
+            ghcr.io/${{ github.repository }}:latest${{ matrix.base }}
+          build-args: |
+            IMAGE=python:${{ matrix.python-version }}${{ matrix.base }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,34 @@
+name: Publish docker image
+on:
+  push:
+    branches: ['main']
+    tags: [v*]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Calculate version
+        id: get_version
+        run: |
+          VERSION=$(git describe --tags | sed "s/^v//")
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo $VERSION
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ steps.get_version.outputs.VERSION }}
+            ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+ARG IMAGE=python:3.11-alpine
+
+FROM $IMAGE as builder
+
+RUN pip install poetry==1.5.1
+
+ENV POETRY_NO_INTERACTION=1 \
+    POETRY_VIRTUALENVS_IN_PROJECT=1 \
+    POETRY_VIRTUALENVS_CREATE=1 \
+    POETRY_CACHE_DIR=/tmp/poetry_cache
+
+WORKDIR /app
+
+COPY . /app
+
+RUN poetry install --without dev --without lsp
+
+FROM $IMAGE as runtime
+
+ENV VIRTUAL_ENV=/app/.venv \
+    PATH="/app/.venv/bin:$PATH"
+
+COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+COPY . /app
+
+ENTRYPOINT ["keymap"]

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See [the development section](#development) for instructions to install from sou
 ### Using docker
 
 ``` sh
-docker pull ghcr.io/caksoylar/keymap-drawer:latest
+docker pull ghcr.io/hnaderi/keymap-drawer:latest
 ```
 
 ### Bootstrapping your keymap representation

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ keymap --help
 Alternatively, you can `pip install keymap-drawer` in a virtual environment or install into your user install directory with `pip install --user keymap-drawer`.
 See [the development section](#development) for instructions to install from source.
 
+### Using docker
+
+``` sh
+docker pull ghcr.io/caksoylar/keymap-drawer:latest
+```
+
 ### Bootstrapping your keymap representation
 
 **`keymap parse`** command helps to parse an existing QMK or ZMK keymap file into the keymap YAML representation the `draw` command uses to generate SVGs.


### PR DESCRIPTION
Hi, Thanks for this great tool!
This PR adds a docker image that is automatically published to the GitHub container registry for `tags` and pushes on `main`.
Having a docker image for the CLI would make it easier to use the CLI in the CI/CD and on other platforms.
