### PR TITLE
allow additional includes to be specified in the parse config

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -381,3 +381,11 @@ The default defines a `KEYMAP_DRAWER` symbol which can be used for checks with p
 _Type:_ `string`
 
 _Default:_ `"#define KEYMAP_DRAWER"`
+
+#### `zmk_additional_includes`
+
+A list of paths to add as search paths to the preprocessor. This can be useful to add the `zmk-helpers` module to the preprocessor. 
+
+_Type:_ `list[str]`
+
+_Default:_ `[]`

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -384,7 +384,7 @@ _Default:_ `"#define KEYMAP_DRAWER"`
 
 #### `zmk_additional_includes`
 
-A list of paths to add as search paths to the preprocessor. This can be useful to add the `zmk-helpers` module to the preprocessor. 
+A list of paths to add as search paths to the preprocessor for `#include` directives. This can be needed if you use Zephyr modules such as [`zmk-helpers`](https://github.com/urob/zmk-helpers/tree/v2) since they require augmenting the search path.
 
 _Type:_ `list[str]`
 

--- a/keymap_drawer/config.py
+++ b/keymap_drawer/config.py
@@ -486,6 +486,8 @@ class ParseConfig(BaseSettings, env_prefix="KEYMAP_", extra="ignore"):
     # prepend this to ZMK keymaps before processing to customize parsing output
     zmk_preamble: str = "#define KEYMAP_DRAWER"
 
+    # additional zmk include paths to be added to the preprocessor
+    zmk_additional_includes: list[str] = []
 
 class Config(BaseSettings, env_prefix="KEYMAP_"):
     """All configuration settings used for this module."""

--- a/keymap_drawer/config.py
+++ b/keymap_drawer/config.py
@@ -489,6 +489,7 @@ class ParseConfig(BaseSettings, env_prefix="KEYMAP_", extra="ignore"):
     # additional zmk include paths to be added to the preprocessor
     zmk_additional_includes: list[str] = []
 
+
 class Config(BaseSettings, env_prefix="KEYMAP_"):
     """All configuration settings used for this module."""
 

--- a/keymap_drawer/parse/dts.py
+++ b/keymap_drawer/parse/dts.py
@@ -101,7 +101,14 @@ class DeviceTree:
     _compatible_re = re.compile(r'compatible = "(.*?)"')
     _custom_data_header = "__keymap_drawer_data__"
 
-    def __init__(self, in_str: str, file_name: str | None = None, preprocess: bool = True, preamble: str | None = None, additional_includes: list[str] = []):
+    def __init__(
+        self,
+        in_str: str,
+        file_name: str | None = None,
+        preprocess: bool = True,
+        preamble: str | None = None,
+        additional_includes: list[str] = [],
+    ):
         """
         Given an input DTS string `in_str` and `file_name` it is read from, parse it into an internap
         tree representation and track what "compatible" value each node has.

--- a/keymap_drawer/parse/dts.py
+++ b/keymap_drawer/parse/dts.py
@@ -101,13 +101,13 @@ class DeviceTree:
     _compatible_re = re.compile(r'compatible = "(.*?)"')
     _custom_data_header = "__keymap_drawer_data__"
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         in_str: str,
         file_name: str | None = None,
         preprocess: bool = True,
         preamble: str | None = None,
-        additional_includes: list[str] = [],
+        additional_includes: list[str] | None = None,
     ):
         """
         Given an input DTS string `in_str` and `file_name` it is read from, parse it into an internap
@@ -160,7 +160,7 @@ class DeviceTree:
                     self.chosen.content += " " + node.content
 
     @staticmethod
-    def _preprocess(in_str: str, file_name: str | None = None, additional_includes: list[str] = []) -> str:
+    def _preprocess(in_str: str, file_name: str | None = None, additional_includes: list[str] | None = None) -> str:
         def include_handler(*args):  # type: ignore
             raise OutputDirective(Action.IgnoreAndPassThrough)
 
@@ -168,7 +168,7 @@ class DeviceTree:
         preprocessor.line_directive = None
         preprocessor.on_include_not_found = include_handler
         preprocessor.assume_encoding = "utf-8"
-        for path in additional_includes:
+        for path in additional_includes or []:
             preprocessor.add_path(path)
         preprocessor.parse(in_str, source=file_name)
 

--- a/keymap_drawer/parse/zmk.py
+++ b/keymap_drawer/parse/zmk.py
@@ -240,7 +240,7 @@ class ZmkKeymapParser(KeymapParser):
         """
         Parse a ZMK keymap with its content and path and return the layout spec and KeymapData to be dumped to YAML.
         """
-        dts = DeviceTree(in_str, file_name, self.cfg.preprocess, preamble=self.cfg.zmk_preamble)
+        dts = DeviceTree(in_str, file_name, self.cfg.preprocess, preamble=self.cfg.zmk_preamble, additional_includes=self.cfg.zmk_additional_includes)
 
         if self.cfg.preprocess and self.raw_binding_map:
             self._update_raw_binding_map(dts)

--- a/keymap_drawer/parse/zmk.py
+++ b/keymap_drawer/parse/zmk.py
@@ -240,7 +240,13 @@ class ZmkKeymapParser(KeymapParser):
         """
         Parse a ZMK keymap with its content and path and return the layout spec and KeymapData to be dumped to YAML.
         """
-        dts = DeviceTree(in_str, file_name, self.cfg.preprocess, preamble=self.cfg.zmk_preamble, additional_includes=self.cfg.zmk_additional_includes)
+        dts = DeviceTree(
+            in_str,
+            file_name,
+            self.cfg.preprocess,
+            preamble=self.cfg.zmk_preamble,
+            additional_includes=self.cfg.zmk_additional_includes,
+        )
 
         if self.cfg.preprocess and self.raw_binding_map:
             self._update_raw_binding_map(dts)


### PR DESCRIPTION
implements part of https://github.com/caksoylar/keymap-drawer/issues/101
This PR adds support for additional includes to be passed to the preprocessor. 
This in turn adds support for `zmk-helpers` as its path can be added to the parser config as follows

```yaml
parse_config:
    zmk_additional_includes:
      - "zmk-helpers/include"
```

While this does not parse the `west.yaml`, i think it should be sufficient for most, if not all, use cases. As most configurations will not have many additional includes. 

To fully implement #101 the workflow also has to be updated to pull `west` modules. I plan on picking this up seperately