### PR TITLE
Feature/add west config path to workflow

### DIFF
--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -99,6 +99,9 @@ jobs:
         if: inputs.install_branch != ''
         run: python3 -m pip install "git+${{ inputs.install_repo }}@${{ inputs.install_branch }}"
 
+      - name: Install west
+        run: python3 -m pip install west
+
       - name: Cache west modules
         uses: actions/cache@v3.0.11
         continue-on-error: true

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -121,7 +121,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: West Init
-        run: west init -l ${{ inputs.config_path }}
+        run: west init -l ./config/ #todo fix hardcoded path
 
       - name: West Update
         run: west update

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -99,6 +99,30 @@ jobs:
         if: inputs.install_branch != ''
         run: python3 -m pip install "git+${{ inputs.install_repo }}@${{ inputs.install_branch }}"
 
+      - name: Cache west modules
+        uses: actions/cache@v3.0.11
+        continue-on-error: true
+        env:
+          cache_name: cache-zephyr-${{ env.zephyr_version }}-modules
+        with:
+          path: |
+            modules/
+            tools/
+            zephyr/
+            bootloader/
+            zmk/
+          key: ${{ runner.os }}-build-${{ env.cache_name }}-${{ hashFiles('**/west.yml', '**/build.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache_name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: West Init
+        run: west init -l ${{ inputs.config_path }}
+
+      - name: West Update
+        run: west update
+
       - name: Draw keymaps
         id: draw
         run: |

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -15,7 +15,7 @@ on:
         required: false
         type: string
       west_config_path:
-        description: 'Path to where west.yaml is stored, e.g. `./config/`. If specified, west will be initialised'
+        description: 'Path to the folder containing west.yml, e.g. `config`. If specified, west will be initialized to fetch modules defined in west.yml'
         default: ''
         required: false
         type: string

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -14,6 +14,11 @@ on:
         default: 'keymap_drawer.config.yaml'
         required: false
         type: string
+      west_config_path:
+        description: 'Path to where west.yaml is stored, e.g. `./config/`. If specified, west will be initialised'
+        default: ''
+        required: false
+        type: string
       output_folder:
         description: 'Output folder for SVG and YAML files'
         default: 'keymap-drawer'
@@ -100,9 +105,11 @@ jobs:
         run: python3 -m pip install "git+${{ inputs.install_repo }}@${{ inputs.install_branch }}"
 
       - name: Install west
+        if: inputs.west_config_path != ''
         run: python3 -m pip install west
 
       - name: Cache west modules
+        if: inputs.west_config_path != ''
         uses: actions/cache@v3.0.11
         continue-on-error: true
         env:
@@ -121,9 +128,11 @@ jobs:
             ${{ runner.os }}-
 
       - name: West Init
-        run: west init -l ./config/ #todo fix hardcoded path
+        if: inputs.west_config_path != ''
+        run: west init -l ${{ inputs.west_config_path }}
 
       - name: West Update
+        if: inputs.west_config_path != ''
         run: west update
 
       - name: Draw keymaps

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -113,7 +113,7 @@ jobs:
         uses: actions/cache@v4
         continue-on-error: true
         env:
-          cache_name: cache-zephyr-${{ env.zephyr_version }}-modules
+          cache_name: cache-zephyr-3.5.0-modules
         with:
           path: |
             modules/

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Cache west modules
         if: inputs.west_config_path != ''
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         continue-on-error: true
         env:
           cache_name: cache-zephyr-${{ env.zephyr_version }}-modules


### PR DESCRIPTION
Follow up of (and requires): https://github.com/caksoylar/keymap-drawer/pull/105

Took a bit of trial and error, but we got there. 

Adds a `west_config_path` input to the draw workflow. If specified it will initialise and update west. If not specified, it has no affect. Thus also not slowing down any workflows. 

Example of an uninitialised failed workflow: https://github.com/stijnveenman/zmk-config/actions/runs/9847346357/job/27187112733#step:9:71

Example of a initialised successful workflow: https://github.com/stijnveenman/zmk-config/actions/runs/9847355106/job/27187141109

With the following settings:

**draw.yml**
```yaml 
jobs:
  draw:
    uses: stijnveenman/keymap-drawer/.github/workflows/draw-zmk.yml@feature/west-init
    permissions:
      contents: write  # allow workflow to commit to the repo
    with:
      keymap_patterns: "config/cradio.keymap"        # path to the keymaps to parse
      destination: 'artifact'
      install_repo: 'https://github.com/stijnveenman/keymap-drawer.git'
      install_branch: 'feature/additional_includes'
      config_path: 'draw-config.yaml'
      west_config_path: './config/'
```

**draw-config.yaml**
```yaml
parse_config:
    zmk_additional_includes:
      - "zmk-helpers/include"
```