### PR TITLE
Avoid newlines between 2 tspan elements

### DIFF
--- a/keymap_drawer/draw/utils.py
+++ b/keymap_drawer/draw/utils.py
@@ -105,8 +105,8 @@ class UtilsMixin(GlyphMixin):
         scaling = self._get_scaling(max(len(w) for w in words))
         self.out.write(f'<tspan x="{round(p.x)}" dy="-{dy_0}em"{scaling}>{escape(words[0])}</tspan>')
         for word in words[1:]:
-            self.out.write(f'<tspan x="{round(p.x)}" dy="{self.cfg.line_spacing}em"{scaling}>{escape(word)}</tspan>\n')
-        self.out.write("</text>\n")
+            self.out.write(f'<tspan x="{round(p.x)}" dy="{self.cfg.line_spacing}em"{scaling}>{escape(word)}</tspan>')
+        self.out.write("\n</text>\n")
 
     def _draw_glyph(self, p: Point, name: str, legend_type: LegendType, classes: Sequence[str]) -> None:
         width, height, d_y = self.get_glyph_dimensions(name, legend_type)


### PR DESCRIPTION
This whitespace messes up word alignment when placed in between 2 tspan elements, causes misalignment when rendering more than 2 lines of tap text.

It is pretty much an edge-case, but I'm using a custom keymap as legend for the real keymap. And some of the legend labels have more than 2 words.

| Before | After
| --- | ---
| ![image](https://github.com/user-attachments/assets/1ac3caf1-efc7-47be-ad37-b250a5cef01f) | ![image](https://github.com/user-attachments/assets/3144abb9-4d50-4712-9d9a-10d03eb3d4b4)

