### PR TITLE
fix: use pipx for installs in draw-zmk.yml (PEP 668)

### DIFF
--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -98,15 +98,15 @@ jobs:
 
       - name: Install keymap-drawer (pypi)
         if: inputs.install_branch == ''
-        run: python3 -m pipx install keymap-drawer
+        run: pipx install keymap-drawer
 
       - name: Install keymap-drawer (git)
         if: inputs.install_branch != ''
-        run: python3 -m pipx install "git+${{ inputs.install_repo }}@${{ inputs.install_branch }}"
+        run: pipx install "git+${{ inputs.install_repo }}@${{ inputs.install_branch }}"
 
       - name: Install west
         if: inputs.west_config_path != ''
-        run: python3 -m pipx install west
+        run: pipx install west
 
       - name: Cache west modules
         if: inputs.west_config_path != ''

--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -98,15 +98,15 @@ jobs:
 
       - name: Install keymap-drawer (pypi)
         if: inputs.install_branch == ''
-        run: python3 -m pip install keymap-drawer
+        run: python3 -m pipx install keymap-drawer
 
       - name: Install keymap-drawer (git)
         if: inputs.install_branch != ''
-        run: python3 -m pip install "git+${{ inputs.install_repo }}@${{ inputs.install_branch }}"
+        run: python3 -m pipx install "git+${{ inputs.install_repo }}@${{ inputs.install_branch }}"
 
       - name: Install west
         if: inputs.west_config_path != ''
-        run: python3 -m pip install west
+        run: python3 -m pipx install west
 
       - name: Cache west modules
         if: inputs.west_config_path != ''


### PR DESCRIPTION
Make workflow [PEP 668](https://peps.python.org/pep-0668/) complaint, to avoid below errors in workflows.

```
Run python3 -m pip install keymap-drawer
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP [6](https://github.com/janwvjaarsveld/aurora-corne-zmk-config/actions/runs/11332726345/job/31515457850#step:3:7)68 for the detailed specification.
Error: Process completed with exit code 1.
```