### PR TITLE
ci(draw-zmk): enable extended globbing for pattern matching

### DIFF
--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -151,6 +151,7 @@ jobs:
               done
           }
 
+          shopt -s extglob
           declare -a DRAWINGS
           error_occurred=0
           mkdir -p "${{ inputs.output_folder }}"


### PR DESCRIPTION
This will allow for more advanced patterns of `keymap_patterns` to be defined and picked up.