### PR TITLE
docs: correcting cli args

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ And you are done! You can view the output SVG on your browser or use a tool like
 > #### ℹ️ Specifying layouts in the CLI
 >
 > If you like you can override the layout specification on the command line.
-> For instance you can provide a QMK keyboard name with `-q`/`--qmk-keyboard` and layout with `-l`/`--qmk-layout`,
+> For instance you can provide a QMK keyboard name with `-k`/`--qmk-keyboard` and layout with `-l`/`--qmk-layout`,
 > or an ortho layout with `--ortho-layout` (using YAML syntax for the value) or `-n`/`--cols-thumbs-notation`.
 > See `keymap draw --help` for details.
 


### PR DESCRIPTION
keyamp's draw commands takes `--qmk-keyboard QMK_KEYBOARD` or `-k QMK_KEYBOARD` as argument.