### PR TITLE
Support left/right tap key labels

### DIFF
--- a/keymap_drawer/config.py
+++ b/keymap_drawer/config.py
@@ -79,6 +79,9 @@ class DrawConfig(BaseSettings, env_prefix="KEYMAP_", extra="ignore"):
     legend_rel_x: float = 0
     legend_rel_y: float = 0
 
+    # FIXME: better naming of the configuration and explanation to indicate that this refers to the fraction of the width where the right label will be set with respect to the center (defined by the tap)
+    legend_right_rel_w: float = 4
+
     # draw key sides
     draw_key_sides: bool = False
 
@@ -160,8 +163,18 @@ class DrawConfig(BaseSettings, env_prefix="KEYMAP_", extra="ignore"):
             }
 
             /* styling for combo tap, and key hold/shifted label text */
-            text.combo, text.hold, text.shifted {
+            text.combo, text.hold, text.shifted, text.left, text.right {
                 font-size: 11px;
+            }
+
+            text.left {
+                text-anchor: start;
+                dominant-baseline: auto;
+            }
+
+            text.right {
+                text-anchor: start;
+                dominant-baseline: auto;
             }
 
             text.hold {

--- a/keymap_drawer/draw/combo.py
+++ b/keymap_drawer/draw/combo.py
@@ -141,6 +141,19 @@ class ComboDrawerMixin(UtilsMixin):
             classes=["combo", combo.type, combo.key.type],
             legend_type="tap",
         )
+        # FIXME: combos were not test
+        self._draw_legend(
+            p - Point(self.cfg.combo_w / 2 - self.cfg.small_pad, 0),
+            [combo.key.left],
+            classes=["combo", combo.type, combo.key.type],
+            legend_type="left",
+        )
+        self._draw_legend(
+            p + Point(self.cfg.combo_w / self.cfg.legend_right_rel_w - self.cfg.inner_pad_w - self.cfg.small_pad, 0),
+            [combo.key.right],
+            classes=["combo", combo.type, combo.key.type],
+            legend_type="right",
+        )
         self._draw_legend(
             p + Point(0, self.cfg.combo_h / 2 - self.cfg.small_pad),
             [combo.key.hold],

--- a/keymap_drawer/draw/draw.py
+++ b/keymap_drawer/draw/draw.py
@@ -95,6 +95,18 @@ class KeymapDrawer(ComboDrawerMixin, UtilsMixin):
             shift=shift,
         )
         self._draw_legend(
+            tap_shift - Point(w / 2 - self.cfg.inner_pad_w - self.cfg.small_pad, 0),
+            [l_key.left],
+            classes=["key", l_key.type],
+            legend_type="left"
+        )
+        self._draw_legend(
+            tap_shift + Point(w / self.cfg.legend_right_rel_w - self.cfg.inner_pad_w - self.cfg.small_pad, 0),
+            [l_key.right],
+            classes=["key", l_key.type],
+            legend_type="right",
+        )
+        self._draw_legend(
             Point(0, h / 2 - self.cfg.inner_pad_h - self.cfg.small_pad),
             [l_key.hold],
             classes=["key", l_key.type],

--- a/keymap_drawer/draw/glyph.py
+++ b/keymap_drawer/draw/glyph.py
@@ -42,7 +42,7 @@ class GlyphMixin:
         """Preprocess all glyphs in the keymap to get their name to SVG mapping."""
 
         def find_key_glyph_names(key: LayoutKey) -> set[str]:
-            return {glyph for field in (key.tap, key.hold, key.shifted) if (glyph := self._legend_to_name(field))}
+            return {glyph for field in (key.tap, key.hold, key.shifted, key.left, key.right) if (glyph := self._legend_to_name(field))}
 
         # find all named glyphs in the keymap
         names = set()

--- a/keymap_drawer/draw/utils.py
+++ b/keymap_drawer/draw/utils.py
@@ -9,7 +9,7 @@ from keymap_drawer.config import DrawConfig
 from keymap_drawer.draw.glyph import GlyphMixin
 from keymap_drawer.physical_layout import Point
 
-LegendType = Literal["tap", "hold", "shifted"]
+LegendType = Literal["tap", "hold", "shifted", "left", "right"]
 
 
 class UtilsMixin(GlyphMixin):

--- a/keymap_drawer/keymap.py
+++ b/keymap_drawer/keymap.py
@@ -17,12 +17,15 @@ from keymap_drawer.physical_layout import PhysicalLayout, layout_factory
 class LayoutKey(BaseModel, populate_by_name=True, coerce_numbers_to_str=True, extra="forbid"):
     """
     Represents a binding in the keymap, which has a tap property by default and
-    can optionally have hold or shifted properties, or be "held" or be a "ghost" key.
+    can optionally have hold or shifted properties, left or right labels, or be "held" or be a "ghost" key.
     """
 
     tap: str = Field(alias="t", default="")
     hold: str = Field(alias="h", default="")
     shifted: str = Field(alias="s", default="")
+    left: str = ""
+    right: str = ""
+
     type: str = ""  # pre-defined types: "held" | "ghost"
 
     @classmethod
@@ -42,13 +45,13 @@ class LayoutKey(BaseModel, populate_by_name=True, coerce_numbers_to_str=True, ex
     @model_serializer
     def serialize_model(self) -> str | dict[str, str]:
         """Custom serializer to output string-only for simple legends."""
-        if self.hold or self.shifted or self.type:
-            return {k: v for k, v in (("t", self.tap), ("h", self.hold), ("s", self.shifted), ("type", self.type)) if v}
+        if self.hold or self.shifted or self.left or self.right or self.type:
+            return {k: v for k, v in (("t", self.tap), ("h", self.hold), ("s", self.shifted), ("left", self.left), ("right", self.right), ("type", self.type)) if v}
         return self.tap
 
     def full_serializer(self) -> dict[str, str]:
         """Custom serializer that always outputs a dict."""
-        return {k: v for k in ("tap", "hold", "shifted", "type") if (v := getattr(self, k))}
+        return {k: v for k in ("tap", "hold", "shifted", "left", "right", "type") if (v := getattr(self, k))}
 
     def apply_formatter(self, formatter: Callable[[str], str]) -> None:
         """Add a formatter function (str -> str) to all non-empty fields."""
@@ -58,6 +61,10 @@ class LayoutKey(BaseModel, populate_by_name=True, coerce_numbers_to_str=True, ex
             self.hold = formatter(self.hold)
         if self.shifted:
             self.shifted = formatter(self.shifted)
+        if self.left:
+            self.left = formatter(self.left)
+        if self.right:
+            self.right = formatter(self.right)
 
 
 class ComboSpec(BaseModel, populate_by_name=True, extra="forbid"):


### PR DESCRIPTION
Support left/right tap key labels, to enable drawing AltGr and other international layouts (see #32 and #50).

An example was created (without combos) to discuss on top of it:
 
Without sides:
![imagen](https://github.com/user-attachments/assets/bbd16006-4197-4beb-b8a0-63dd3e37ee36)

With sides:
![imagen](https://github.com/user-attachments/assets/c386d4e9-101a-402d-8432-f6a6c7b8e2f3)

<details><summary>Layout file</summary>

```yaml
layout:
  ortho_layout:
    rows: 3
    columns: 4
layers:
  default:
    - { t: 1A, s: S1A, h: H1A, left: L1A, right: R1A }
    - { t: 1B, s: S1B, h: H1B, left: L1B }
    - { t: 1C, s: S1C, h: H1C, right: R1C }

    - { t: 2A, s: S2A, left: L2A, right: R2A }
    - { t: 2B, s: S2B, left: L2B }
    - { t: 2C, s: S2C, right: R2C }

    - { t: 3A, h: H3A, left: L3A, right: R3A }
    - { t: 3B, h: H3B, left: L3B }
    - { t: 3C, h: H3C, right: R3C }

    - { t: 4A, left: L4A, right: R4A }
    - { t: 4B, left: L4B }
    - { t: 4C, right: R4C }
  spanish_keys:
    - { t: 1, s: "!", right: "|" }
    - { t: 2, s: '"', right: "@" }
    - { t: 3, s: "·", right: "#" }

    - { t: 4, s: "$", right: "◌̃ " }
    - { t: 5, s: "%", right: "€" }
    - { t: 6, s: "&", right: "¬" }

    - { t: 7, s: "/" }
    - { t: 8, s: "(" }
    - { t: 9, s: ")" }

    - { t: 0, s: "=" }
    - { t: "◌́ ", s: "◌¨", right: "{" }
    - { t: "Ç", right: "}" }
```

</details> 

