### PR TITLE
feat: add corner legend positions (tl, tr, bl, br) to LayoutKey

### DIFF
--- a/KEYMAP_SPEC.md
+++ b/KEYMAP_SPEC.md
@@ -66,16 +66,20 @@ A `LayoutKey` can be defined with either a string value or with a mapping with t
 | `shifted`  | `s`, `top`    | `str` | `""`          | the "shifted" action of a key, drawn on the top of the key                                                                                                                                                                                                                  |
 | `left`     |               | `str` | `""`          | left legend, drawn on the left-center of the key                                                                                                                                                                                                                            |
 | `right`    |               | `str` | `""`          | right legend, drawn on the right-center of the key                                                                                                                                                                                                                          |
+| `tl`       |               | `str` | `""`          | top-left corner legend                                                                                                                                                                                                                                                      |
+| `tr`       |               | `str` | `""`          | top-right corner legend                                                                                                                                                                                                                                                     |
+| `bl`       |               | `str` | `""`          | bottom-left corner legend                                                                                                                                                                                                                                                   |
+| `br`       |               | `str` | `""`          | bottom-right corner legend                                                                                                                                                                                                                                                  |
 | `type`     |               | `str` | `""`          | the styling of the key that corresponds to the [SVG class](CONFIGURATION.md#svg_style)[^4]. predefined types are `held` (a red shading to denote held down keys), `ghost` (dashed outline to denote optional keys in a layout), `trans` (lighter text for transparent keys) |
 
 [^3]: You can prevent line breaks by using double spaces `"  "` to denote a single non-breaking space.
 
-[^4]: Text styling can be overridden in the `svg_extra_style` field under `draw_config` using the `"tap"`, `"hold"`, `"shifted"`, `"left"` and `"right"` CSS classes if desired.
+[^4]: Text styling can be overridden in the `svg_extra_style` field under `draw_config` using the `"tap"`, `"hold"`, `"shifted"`, `"left"`, `"right"`, `"tl"`, `"tr"`, `"bl"` and `"br"` CSS classes if desired.
 
 Using a string value such as `"A"` for a key spec is equivalent to defining a mapping with only the tap field, i.e., `{tap: "A"}`.
 It is meant to be used as a shortcut for keys that do not need any other fields.
 
-You can use the special `$$..$$` syntax to refer to custom SVG glyphs in `tap`/`hold`/`shifted`/`left`/`right` fields, however note that they cannot be used with other text or glyphs inside the same field value.
+You can use the special `$$..$$` syntax to refer to custom SVG glyphs in `tap`/`hold`/`shifted`/`left`/`right`/`tl`/`tr`/`bl`/`br` fields, however note that they cannot be used with other text or glyphs inside the same field value.
 See the [custom glyphs section](README.md#custom-glyphs) for more information.
 
 `layers` field also flattens any lists that are contained in its value: This allows you to semantically divide keys to "rows," if you prefer to do so.

--- a/keymap_drawer/config.py
+++ b/keymap_drawer/config.py
@@ -160,25 +160,25 @@ class DrawConfig(BaseSettings, env_prefix="KEYMAP_", extra="ignore"):
             }
 
             /* styling for combo tap, and key non-tap label text */
-            text.combo, text.hold, text.shifted, text.left, text.right {
+            text.combo, text.hold, text.shifted, text.left, text.right, text.tl, text.tr, text.bl, text.br {
                 font-size: 11px;
             }
 
-            text.hold {
+            text.hold, text.bl, text.br {
                 text-anchor: middle;
                 dominant-baseline: auto;
             }
 
-            text.shifted {
+            text.shifted, text.tl, text.tr {
                 text-anchor: middle;
                 dominant-baseline: hanging;
             }
 
-            text.left {
+            text.left, text.tl, text.bl {
                 text-anchor: start;
             }
 
-            text.right {
+            text.right, text.tr, text.br {
                 text-anchor: end;
             }
 

--- a/keymap_drawer/draw/draw.py
+++ b/keymap_drawer/draw/draw.py
@@ -49,13 +49,12 @@ class KeymapDrawer(ComboDrawerMixin, UtilsMixin):
         Print SVG code for a rectangle with text representing the key, which is described by its physical
         representation (p_key) and what it does in the given layer (l_key).
         """
-        p, w, h, r = (
+        p, w, h = (
             p_key.pos,
             p_key.width,
             p_key.height,
-            p_key.rotation,
         )
-        rotate_str = f" rotate({r})" if r != 0 else ""
+        rotate_str = f" rotate({p_key.rotation})" if p_key.rotation != 0 else ""
         transform_attr = f' transform="translate({round(p.x)}, {round(p.y)}){rotate_str}"'
         class_str = self._to_class_str(["key", l_key.type, f"keypos-{key_ind}"])
         self.out.write(f"<g{transform_attr}{class_str}>\n")
@@ -87,6 +86,9 @@ class KeymapDrawer(ComboDrawerMixin, UtilsMixin):
         if self.cfg.draw_key_sides:
             tap_shift -= Point(self.cfg.key_side_pars.rel_x, self.cfg.key_side_pars.rel_y)
 
+        x_offset = w / 2 - self.cfg.inner_pad_w - self.cfg.small_pad
+        y_offset = h / 2 - self.cfg.inner_pad_h - self.cfg.small_pad
+
         self._draw_legend(
             tap_shift,
             tap_words,
@@ -95,54 +97,51 @@ class KeymapDrawer(ComboDrawerMixin, UtilsMixin):
             shift=shift,
         )
         self._draw_legend(
-            Point(0, h / 2 - self.cfg.inner_pad_h - self.cfg.small_pad),
+            Point(0, y_offset),
             [l_key.hold],
             classes=["key", l_key.type],
             legend_type="hold",
         )
         self._draw_legend(
-            Point(0, -h / 2 + self.cfg.inner_pad_h + self.cfg.small_pad),
+            Point(0, -y_offset),
             [l_key.shifted],
             classes=["key", l_key.type],
             legend_type="shifted",
         )
         self._draw_legend(
-            Point(-w / 2 + self.cfg.inner_pad_w + self.cfg.small_pad, 0),
+            Point(-x_offset, 0),
             [l_key.left],
             classes=["key", l_key.type],
             legend_type="left",
         )
         self._draw_legend(
-            Point(w / 2 - self.cfg.inner_pad_w - self.cfg.small_pad, 0),
+            Point(x_offset, 0),
             [l_key.right],
             classes=["key", l_key.type],
             legend_type="right",
         )
 
-        # Corner legends
-        corner_pad = self.cfg.small_pad
-        corner_x = w / 2 - self.cfg.inner_pad_w - corner_pad
-        corner_y = h / 2 - self.cfg.inner_pad_h - corner_pad
+        # corner legends
         self._draw_legend(
-            Point(-corner_x, -corner_y),
+            Point(-x_offset, -y_offset),
             [l_key.tl],
             classes=["key", l_key.type],
             legend_type="tl",
         )
         self._draw_legend(
-            Point(corner_x, -corner_y),
+            Point(x_offset, -y_offset),
             [l_key.tr],
             classes=["key", l_key.type],
             legend_type="tr",
         )
         self._draw_legend(
-            Point(-corner_x, corner_y),
+            Point(-x_offset, y_offset),
             [l_key.bl],
             classes=["key", l_key.type],
             legend_type="bl",
         )
         self._draw_legend(
-            Point(corner_x, corner_y),
+            Point(x_offset, y_offset),
             [l_key.br],
             classes=["key", l_key.type],
             legend_type="br",

--- a/keymap_drawer/draw/draw.py
+++ b/keymap_drawer/draw/draw.py
@@ -119,6 +119,35 @@ class KeymapDrawer(ComboDrawerMixin, UtilsMixin):
             legend_type="right",
         )
 
+        # Corner legends
+        corner_pad = self.cfg.small_pad
+        corner_x = w / 2 - self.cfg.inner_pad_w - corner_pad
+        corner_y = h / 2 - self.cfg.inner_pad_h - corner_pad
+        self._draw_legend(
+            Point(-corner_x, -corner_y),
+            [l_key.tl],
+            classes=["key", l_key.type],
+            legend_type="tl",
+        )
+        self._draw_legend(
+            Point(corner_x, -corner_y),
+            [l_key.tr],
+            classes=["key", l_key.type],
+            legend_type="tr",
+        )
+        self._draw_legend(
+            Point(-corner_x, corner_y),
+            [l_key.bl],
+            classes=["key", l_key.type],
+            legend_type="bl",
+        )
+        self._draw_legend(
+            Point(corner_x, corner_y),
+            [l_key.br],
+            classes=["key", l_key.type],
+            legend_type="br",
+        )
+
         self.out.write("</g>\n")
 
     def print_layers(  # pylint: disable=too-many-locals

--- a/keymap_drawer/draw/glyph.py
+++ b/keymap_drawer/draw/glyph.py
@@ -47,7 +47,7 @@ class GlyphMixin:
         def find_key_glyph_names(key: LayoutKey) -> set[str]:
             return {
                 glyph
-                for field in (key.tap, key.hold, key.shifted, key.left, key.right)
+                for field in (key.tap, key.hold, key.shifted, key.left, key.right, key.tl, key.tr, key.bl, key.br)
                 if (glyph := self._legend_to_name(field))
             }
 
@@ -156,6 +156,26 @@ class GlyphMixin:
                 width = w * height / h
                 d_x = width
                 d_y = 0.5 * height
+            case "tl":  # top-left corner
+                height = self.cfg.glyph_shifted_size
+                width = w * height / h
+                d_x = 0
+                d_y = 0
+            case "tr":  # top-right corner
+                height = self.cfg.glyph_shifted_size
+                width = w * height / h
+                d_x = width
+                d_y = 0
+            case "bl":  # bottom-left corner
+                height = self.cfg.glyph_shifted_size
+                width = w * height / h
+                d_x = 0
+                d_y = height
+            case "br":  # bottom-right corner
+                height = self.cfg.glyph_shifted_size
+                width = w * height / h
+                d_x = width
+                d_y = height
             case _:
                 raise ValueError("Unsupported legend_type for glyph")
 

--- a/keymap_drawer/draw/utils.py
+++ b/keymap_drawer/draw/utils.py
@@ -11,7 +11,7 @@ from keymap_drawer.config import DrawConfig
 from keymap_drawer.draw.glyph import GlyphMixin
 from keymap_drawer.physical_layout import Point
 
-LegendType = Literal["tap", "hold", "shifted", "left", "right"]
+LegendType = Literal["tap", "hold", "shifted", "left", "right", "tl", "tr", "bl", "br"]
 
 
 class UtilsMixin(GlyphMixin):

--- a/keymap_drawer/keymap.py
+++ b/keymap_drawer/keymap.py
@@ -14,7 +14,9 @@ from keymap_drawer.config import Config
 from keymap_drawer.physical_layout import PhysicalLayout, PhysicalLayoutGenerator
 
 
-class LayoutKey(BaseModel, populate_by_name=True, coerce_numbers_to_str=True, extra="forbid"):
+class LayoutKey(
+    BaseModel, populate_by_name=True, coerce_numbers_to_str=True, extra="forbid"
+):  # pylint: disable=too-many-instance-attributes
     """
     Represents a binding in the keymap, which has a tap property by default and
     can optionally have hold or shifted properties, left or right labels, or be "held" or be a "ghost" key.
@@ -25,8 +27,6 @@ class LayoutKey(BaseModel, populate_by_name=True, coerce_numbers_to_str=True, ex
     shifted: str = Field(validation_alias=AliasChoices("shifted", "s"), serialization_alias="s", default="")
     left: str = ""
     right: str = ""
-
-    # Corner positions for multi-legend keys
     tl: str = ""  # top-left corner
     tr: str = ""  # top-right corner
     bl: str = ""  # bottom-left corner
@@ -51,7 +51,7 @@ class LayoutKey(BaseModel, populate_by_name=True, coerce_numbers_to_str=True, ex
     @model_serializer
     def serialize_model(self) -> str | dict[str, str]:
         """Custom serializer to output string-only for simple legends."""
-        if self.hold or self.shifted or self.left or self.right or self.tl or self.tr or self.bl or self.br or self.type:
+        if any((self.hold, self.shifted, self.left, self.right, self.tl, self.tr, self.bl, self.br, self.type)):
             return {
                 k: v
                 for k, v in (
@@ -72,7 +72,11 @@ class LayoutKey(BaseModel, populate_by_name=True, coerce_numbers_to_str=True, ex
 
     def full_serializer(self) -> dict[str, str]:
         """Custom serializer that always outputs a dict."""
-        return {k: v for k in ("tap", "hold", "shifted", "left", "right", "tl", "tr", "bl", "br", "type") if (v := getattr(self, k))}
+        return {
+            k: v
+            for k in ("tap", "hold", "shifted", "left", "right", "tl", "tr", "bl", "br", "type")
+            if (v := getattr(self, k))
+        }
 
     def apply_formatter(self, formatter: Callable[[str], str]) -> None:
         """Add a formatter function (str -> str) to all non-empty fields."""

--- a/keymap_drawer/keymap.py
+++ b/keymap_drawer/keymap.py
@@ -26,6 +26,12 @@ class LayoutKey(BaseModel, populate_by_name=True, coerce_numbers_to_str=True, ex
     left: str = ""
     right: str = ""
 
+    # Corner positions for multi-legend keys
+    tl: str = ""  # top-left corner
+    tr: str = ""  # top-right corner
+    bl: str = ""  # bottom-left corner
+    br: str = ""  # bottom-right corner
+
     type: str = ""  # pre-defined types: "held" | "ghost"
 
     @classmethod
@@ -45,7 +51,7 @@ class LayoutKey(BaseModel, populate_by_name=True, coerce_numbers_to_str=True, ex
     @model_serializer
     def serialize_model(self) -> str | dict[str, str]:
         """Custom serializer to output string-only for simple legends."""
-        if self.hold or self.shifted or self.left or self.right or self.type:
+        if self.hold or self.shifted or self.left or self.right or self.tl or self.tr or self.bl or self.br or self.type:
             return {
                 k: v
                 for k, v in (
@@ -54,6 +60,10 @@ class LayoutKey(BaseModel, populate_by_name=True, coerce_numbers_to_str=True, ex
                     ("s", self.shifted),
                     ("left", self.left),
                     ("right", self.right),
+                    ("tl", self.tl),
+                    ("tr", self.tr),
+                    ("bl", self.bl),
+                    ("br", self.br),
                     ("type", self.type),
                 )
                 if v
@@ -62,7 +72,7 @@ class LayoutKey(BaseModel, populate_by_name=True, coerce_numbers_to_str=True, ex
 
     def full_serializer(self) -> dict[str, str]:
         """Custom serializer that always outputs a dict."""
-        return {k: v for k in ("tap", "hold", "shifted", "left", "right", "type") if (v := getattr(self, k))}
+        return {k: v for k in ("tap", "hold", "shifted", "left", "right", "tl", "tr", "bl", "br", "type") if (v := getattr(self, k))}
 
     def apply_formatter(self, formatter: Callable[[str], str]) -> None:
         """Add a formatter function (str -> str) to all non-empty fields."""
@@ -76,6 +86,14 @@ class LayoutKey(BaseModel, populate_by_name=True, coerce_numbers_to_str=True, ex
             self.left = formatter(self.left)
         if self.right:
             self.right = formatter(self.right)
+        if self.tl:
+            self.tl = formatter(self.tl)
+        if self.tr:
+            self.tr = formatter(self.tr)
+        if self.bl:
+            self.bl = formatter(self.bl)
+        if self.br:
+            self.br = formatter(self.br)
 
 
 class ComboSpec(BaseModel, populate_by_name=True, extra="forbid"):


### PR DESCRIPTION
Adds four new optional fields to LayoutKey for corner positions:
- tl: top-left corner
- tr: top-right corner
- bl: bottom-left corner
- br: bottom-right corner

These can be used to display additional information in the corners of keys, useful for multi-layer reference diagrams.

Closes #151 