### PR TITLE
ci: Bump GitHub Actions for Node.js 24 (Node.js 20 deprecation)

### DIFF
--- a/.github/workflows/draw-zmk.yml
+++ b/.github/workflows/draw-zmk.yml
@@ -76,7 +76,7 @@ jobs:
       drawings: ${{ steps.artifact-upload-step.outputs.artifact-id }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # So the reference to the parent commit is available when amending
           # See:
@@ -214,7 +214,7 @@ jobs:
 
       - name: Commit updated images
         if: ( inputs.destination == 'commit' || inputs.destination == 'both' )
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           file_pattern: '${{ inputs.output_folder }}/*.svg ${{ inputs.output_folder }}/*.yaml'
           # So the previous commit is amended instead of creating a new one when desired
@@ -230,7 +230,7 @@ jobs:
       - name: Artifact upload
         id: artifact-upload-step
         if: ( inputs.destination == 'artifact' || inputs.destination == 'both' )
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: '${{ inputs.artifact_name }}'
           path: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Set up python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -30,7 +30,7 @@ jobs:
 
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-3.10-${{ hashFiles('poetry.lock') }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Set up python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install Poetry
@@ -23,14 +23,14 @@ jobs:
           virtualenvs-in-project: true
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-3.10-${{ hashFiles('poetry.lock') }}
       - name: Build wheel and tarball
         run: poetry build --no-interaction
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions
           path: dist/
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/
@@ -69,14 +69,14 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/
       - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        uses: sigstore/gh-action-sigstore-python@v3.3.0
         with:
           inputs: >-
             ./dist/*.tar.gz

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Set up python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install Poetry
@@ -23,14 +23,14 @@ jobs:
           virtualenvs-in-project: true
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .venv
           key: venv-${{ runner.os }}-3.10-${{ hashFiles('poetry.lock') }}
       - name: Build wheel and tarball
         run: poetry build --no-interaction
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-package-distributions
           path: dist/
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-package-distributions
           path: dist/

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -27,13 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "site"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

GitHub is deprecating JavaScript actions that still run on **Node.js 20**. **Node.js 24** becomes the default for Actions runners on **June 2, 2026**, and Node.js 20 support is slated for removal on **September 16, 2026**. This PR updates workflow pins so we use action releases built for newer runtimes and avoids relying on bundles that triggered the Node 20 deprecation warning (for example `actions/checkout@v4`).

References: [Deprecation of Node.js 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

## Changes

| Area | Updates |
|------|--------|
| **General CI** | `actions/checkout` **v4 → v6**, `actions/setup-python` **v5 → v6**, `actions/cache` **v4 → v5** |
| **Artifacts** | `actions/upload-artifact` **v4 → v7**, `actions/download-artifact` **v4 → v8** (aligned with current upstream pairing) |
| **GitHub Pages** | `actions/configure-pages` **v4 → v6**, `actions/upload-pages-artifact` **v3 → v5**, `actions/deploy-pages` **v4 → v5** |
| **Draw ZMK workflow** | `stefanzweifel/git-auto-commit-action` **v5 → v7** (Node 24 runtime) |
| **Release signing** | `sigstore/gh-action-sigstore-python` **v3.0.0 → v3.3.0** |

Unchanged: `snok/install-poetry@v1` (composite action), `pypa/gh-action-pypi-publish@release/v1` (composite + Docker).

## Testing

- [x] CI (lint workflow) passes on [this branch](https://github.com/daaa1k/keymap-drawer/actions/runs/25216541110/job/73938149968?pr=1).
